### PR TITLE
settings improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+README.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,12 +1311,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "stringprep"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1575,7 +1569,6 @@ dependencies = [
  "serde_json",
  "simplelog",
  "sqlx",
- "static_assertions",
  "textwrap",
  "thiserror",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "tui-journal"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,6 +1311,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stringprep"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1569,6 +1575,7 @@ dependencies = [
  "serde_json",
  "simplelog",
  "sqlx",
+ "static_assertions",
  "textwrap",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ sqlx = {version = "0.6.3", features = ["runtime-tokio-native-tls", "sqlite", "ch
 # TODO: follow issue link: https://github.com/rhysd/tui-textarea/issues/19 and reapplay the migration
 tui = "0.19"
 tui-textarea = "0.2"
+static_assertions = "1.1.0"
 # Textarea crate supports ratatui but it doesn't provide a new version on crates.io to support it
 # crossterm = "0.26"
 # tui = { version = "0.20", package = "ratatui" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ sqlx = {version = "0.6.3", features = ["runtime-tokio-native-tls", "sqlite", "ch
 # TODO: follow issue link: https://github.com/rhysd/tui-textarea/issues/19 and reapplay the migration
 tui = "0.19"
 tui-textarea = "0.2"
-static_assertions = "1.1.0"
 # Textarea crate supports ratatui but it doesn't provide a new version on crates.io to support it
 # crossterm = "0.26"
 # tui = { version = "0.20", package = "ratatui" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-journal"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Ammar Abou Zor"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -92,14 +92,14 @@ $ tjournal --help
 Usage: tjournal [OPTIONS] [COMMAND]
 
 Commands:
-  get-json-path    Gets the current entries Json file path [aliases: gj]
-  get-sqlite-path  Gets the current entries sqlite file path [aliases: gs]
-  help             Print this message or the help of the given subcommand(s)
+  print-config  Print the current settings including the paths for the backend files [aliases: pc]
+  help          Print this message or the help of the given subcommand(s)
 
 Options:
   -j, --json-file-path <FILE PATH>    Sets the entries Json file path and starts using it
   -s, --sqlite-file-path <FILE PATH>  Sets the entries sqlite file path and starts using it
   -b, --backend-type <BACKEND_TYPE>   Sets the backend type and starts using it [possible values: json, sqlite]
+  -w, --write-config                  write the current settings to config file (this will rewrite the whole config file)
   -v, --verbose...                    Increases logging verbosity each use for up to 3 times
   -l, --log <FILE PATH>               Specifies a file to use for logging
                                       (default file: <cache_dir>/tui-journal/tui-journal.log)

--- a/src/settings/json_backend.rs
+++ b/src/settings/json_backend.rs
@@ -7,15 +7,7 @@ use super::get_default_data_dir;
 #[derive(Debug, Deserialize, Serialize, Default)]
 pub struct JsonBackend {
     #[serde(default)]
-    pub file_path: PathBuf,
-}
-
-impl JsonBackend {
-    pub fn get_default() -> anyhow::Result<Self> {
-        Ok(JsonBackend {
-            file_path: get_default_json_path()?,
-        })
-    }
+    pub file_path: Option<PathBuf>,
 }
 
 pub fn get_default_json_path() -> anyhow::Result<PathBuf> {

--- a/src/settings/json_backend.rs
+++ b/src/settings/json_backend.rs
@@ -1,0 +1,22 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use super::get_default_data_dir;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct JsonBackend {
+    pub file_path: PathBuf,
+}
+
+impl JsonBackend {
+    pub fn get_default() -> anyhow::Result<Self> {
+        Ok(JsonBackend {
+            file_path: get_default_json_path()?,
+        })
+    }
+}
+
+pub fn get_default_json_path() -> anyhow::Result<PathBuf> {
+    Ok(get_default_data_dir()?.join("entries.json"))
+}

--- a/src/settings/json_backend.rs
+++ b/src/settings/json_backend.rs
@@ -4,8 +4,9 @@ use serde::{Deserialize, Serialize};
 
 use super::get_default_data_dir;
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct JsonBackend {
+    #[serde(default)]
     pub file_path: PathBuf,
 }
 

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -72,12 +72,14 @@ impl Settings {
     }
 
     pub fn complete_missing_options(&mut self) -> anyhow::Result<()> {
-        // This check is to ensure that all added fields to settings are conisdered here
-        #[cfg(all(feature = "sqlite", feature = "json"))]
-        static_assertions::assert_eq_size!(
-            Settings,
-            (Option<BackendType>, JsonBackend, SqliteBackend)
-        );
+        // This check is to ensure that all added fields to settings struct are conisdered here
+        if cfg!(all(debug_assertions, feature = "sqlite", feature = "json")) {
+            let Settings {
+                backend_type: _,
+                json_backend: __,
+                sqlite_backend: ___,
+            } = self;
+        }
 
         if self.backend_type.is_none() {
             self.backend_type = Some(BackendType::default());

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -5,6 +5,18 @@ use clap::ValueEnum;
 use directories::{BaseDirs, UserDirs};
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "json")]
+use self::json_backend::{get_default_json_path, JsonBackend};
+
+#[cfg(feature = "sqlite")]
+use self::sqlite_backend::{get_default_sqlite_path, SqliteBackend};
+
+#[cfg(feature = "json")]
+mod json_backend;
+
+#[cfg(feature = "sqlite")]
+mod sqlite_backend;
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Settings {
     pub backend_type: BackendType,
@@ -18,36 +30,6 @@ pub struct Settings {
 pub enum BackendType {
     Json,
     Sqlite,
-}
-
-#[cfg(feature = "json")]
-#[derive(Debug, Deserialize, Serialize)]
-pub struct JsonBackend {
-    pub file_path: PathBuf,
-}
-
-#[cfg(feature = "json")]
-impl JsonBackend {
-    fn get_default() -> anyhow::Result<Self> {
-        Ok(JsonBackend {
-            file_path: get_default_json_path()?,
-        })
-    }
-}
-
-#[cfg(feature = "sqlite")]
-#[derive(Debug, Deserialize, Serialize)]
-pub struct SqliteBackend {
-    pub file_path: PathBuf,
-}
-
-#[cfg(feature = "sqlite")]
-impl SqliteBackend {
-    fn get_default() -> anyhow::Result<Self> {
-        Ok(SqliteBackend {
-            file_path: get_default_sqlite_path()?,
-        })
-    }
 }
 
 impl Settings {
@@ -142,14 +124,4 @@ fn get_default_data_dir() -> anyhow::Result<PathBuf> {
                 .join("tui-journal")
         })
         .context("Default entries directory path couldn't be retrieved")
-}
-
-#[cfg(feature = "json")]
-fn get_default_json_path() -> anyhow::Result<PathBuf> {
-    Ok(get_default_data_dir()?.join("entries.json"))
-}
-
-#[cfg(feature = "sqlite")]
-fn get_default_sqlite_path() -> anyhow::Result<PathBuf> {
-    Ok(get_default_data_dir()?.join("entries.db"))
 }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -19,10 +19,13 @@ mod sqlite_backend;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Settings {
+    #[serde(default)]
     pub backend_type: BackendType,
     #[cfg(feature = "json")]
+    #[serde(default)]
     pub json_backend: JsonBackend,
     #[cfg(feature = "sqlite")]
+    #[serde(default)]
     pub sqlite_backend: SqliteBackend,
 }
 
@@ -30,6 +33,15 @@ pub struct Settings {
 pub enum BackendType {
     Json,
     Sqlite,
+}
+
+impl Default for BackendType {
+    fn default() -> Self {
+        #[cfg(all(feature = "json", not(feature = "sqlite")))]
+        return BackendType::Json;
+        #[cfg(feature = "sqlite")]
+        BackendType::Sqlite
+    }
 }
 
 impl Settings {
@@ -83,10 +95,7 @@ impl Settings {
             json_backend: JsonBackend::get_default()?,
             #[cfg(feature = "sqlite")]
             sqlite_backend: SqliteBackend::get_default()?,
-            #[cfg(all(feature = "json", not(feature = "sqlite")))]
-            backend_type: BackendType::Json,
-            #[cfg(feature = "sqlite")]
-            backend_type: BackendType::Sqlite,
+            backend_type: BackendType::default(),
         })
     }
 

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -72,8 +72,13 @@ impl Settings {
     }
 
     pub fn complete_missing_options(&mut self) -> anyhow::Result<()> {
-        //TODO: this method would make errors in the features since there are compiler-checks when
-        // new fields are added to the settings
+        // This check is to ensure that all added fields to settings are conisdered here
+        #[cfg(all(feature = "sqlite", feature = "json"))]
+        static_assertions::assert_eq_size!(
+            Settings,
+            (Option<BackendType>, JsonBackend, SqliteBackend)
+        );
+
         if self.backend_type.is_none() {
             self.backend_type = Some(BackendType::default());
         }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -6,10 +6,9 @@ use directories::{BaseDirs, UserDirs};
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "json")]
-use self::json_backend::JsonBackend;
+use self::json_backend::{get_default_json_path, JsonBackend};
 #[cfg(feature = "sqlite")]
-use self::sqlite_backend::SqliteBackend;
-use self::{json_backend::get_default_json_path, sqlite_backend::get_default_sqlite_path};
+use self::sqlite_backend::{get_default_sqlite_path, SqliteBackend};
 
 #[cfg(feature = "json")]
 pub mod json_backend;
@@ -73,22 +72,23 @@ impl Settings {
 
     pub fn complete_missing_options(&mut self) -> anyhow::Result<()> {
         // This check is to ensure that all added fields to settings struct are conisdered here
-        if cfg!(all(debug_assertions, feature = "sqlite", feature = "json")) {
-            let Settings {
-                backend_type: _,
-                json_backend: __,
-                sqlite_backend: ___,
-            } = self;
-        }
+        #[cfg(all(debug_assertions, feature = "sqlite", feature = "json"))]
+        let Settings {
+            backend_type: _,
+            json_backend: _,
+            sqlite_backend: _,
+        } = self;
 
         if self.backend_type.is_none() {
             self.backend_type = Some(BackendType::default());
         }
 
+        #[cfg(feature = "json")]
         if self.json_backend.file_path.is_none() {
             self.json_backend.file_path = Some(get_default_json_path()?)
         }
 
+        #[cfg(feature = "sqlite")]
         if self.sqlite_backend.file_path.is_none() {
             self.sqlite_backend.file_path = Some(get_default_sqlite_path()?)
         }

--- a/src/settings/sqlite_backend.rs
+++ b/src/settings/sqlite_backend.rs
@@ -4,8 +4,9 @@ use serde::{Deserialize, Serialize};
 
 use super::get_default_data_dir;
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct SqliteBackend {
+    #[serde(default)]
     pub file_path: PathBuf,
 }
 

--- a/src/settings/sqlite_backend.rs
+++ b/src/settings/sqlite_backend.rs
@@ -1,0 +1,22 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use super::get_default_data_dir;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SqliteBackend {
+    pub file_path: PathBuf,
+}
+
+impl SqliteBackend {
+    pub fn get_default() -> anyhow::Result<Self> {
+        Ok(SqliteBackend {
+            file_path: get_default_sqlite_path()?,
+        })
+    }
+}
+
+pub fn get_default_sqlite_path() -> anyhow::Result<PathBuf> {
+    Ok(get_default_data_dir()?.join("entries.db"))
+}

--- a/src/settings/sqlite_backend.rs
+++ b/src/settings/sqlite_backend.rs
@@ -7,15 +7,7 @@ use super::get_default_data_dir;
 #[derive(Debug, Deserialize, Serialize, Default)]
 pub struct SqliteBackend {
     #[serde(default)]
-    pub file_path: PathBuf,
-}
-
-impl SqliteBackend {
-    pub fn get_default() -> anyhow::Result<Self> {
-        Ok(SqliteBackend {
-            file_path: get_default_sqlite_path()?,
-        })
-    }
+    pub file_path: Option<PathBuf>,
 }
 
 pub fn get_default_sqlite_path() -> anyhow::Result<PathBuf> {


### PR DESCRIPTION
This Pull Request fixes/closes #10 

It changes the following:
- Fixes panic if any field in the config file is missing
- Remove rewriting the implicitly and add a command line argument to write the current settings to the config file
- Add command to print the current configs to the command line.
- Remove the commands get-json-file-path  and get_sqlite-file-path since these infos are already in the print-config command
- Improvements to the settings since they will loaded one time only