### PR TITLE
Changed: Help popup improvements

### DIFF
--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -4,7 +4,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use super::ui::UICommand;
 
-#[derive(Debug, Clone, Hash, PartialEq, PartialOrd, Eq)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, PartialOrd, Eq)]
 pub struct Input {
     pub key_code: KeyCode,
     pub modifiers: KeyModifiers,

--- a/src/app/ui/commands/mod.rs
+++ b/src/app/ui/commands/mod.rs
@@ -14,7 +14,7 @@ mod global_cmd;
 
 type CmdResult = anyhow::Result<HandleInputReturnType>;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum UICommand {
     Quit,
     ShowHelp,

--- a/src/app/ui/help_popup.rs
+++ b/src/app/ui/help_popup.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use tui::{
     backend::Backend,
     layout::{Constraint, Rect},
@@ -6,11 +8,13 @@ use tui::{
     Frame,
 };
 
-use super::{commands::CommandInfo, ui_functions::centered_rect, UIComponents};
+use crate::app::keymap::Input;
 
-const KEY_WIDTH: u16 = 10;
-const NAME_PERC: u16 = 30;
-const DESCRIPTION_PERC: u16 = 70;
+use super::{commands::CommandInfo, ui_functions::centered_rect, UICommand, UIComponents};
+
+const KEY_PERC: u16 = 18;
+const NAME_PERC: u16 = 27;
+const DESCRIPTION_PERC: u16 = 100 - NAME_PERC - KEY_PERC;
 const MARGINE: u16 = 8;
 
 pub fn render_help_popup<B: Backend>(
@@ -18,31 +22,48 @@ pub fn render_help_popup<B: Backend>(
     area: Rect,
     ui_components: &UIComponents,
 ) {
-    let area = centered_rect(80, 80, area);
+    let area = centered_rect(90, 80, area);
 
     let header_cells = ["Key", "Command", "Description"]
         .into_iter()
         .map(|header| Cell::from(header).style(Style::default().fg(Color::LightBlue)));
     let header = Row::new(header_cells).height(1).bottom_margin(1);
 
-    let rows = ui_components.get_all_keymaps().map(|keymap| {
-        let key = keymap.key.to_string();
+    let mut unique_commands: BTreeMap<UICommand, Vec<Input>> = BTreeMap::new();
+
+    ui_components.get_all_keymaps().for_each(|keymap| {
+        unique_commands
+            .entry(keymap.command)
+            .and_modify(|keys| keys.push(keymap.key))
+            .or_insert(vec![keymap.key]);
+    });
+
+    let rows = unique_commands.into_iter().map(|(command, keys)| {
+        let keys: Vec<_> = keys.into_iter().map(|input| input.to_string()).collect();
+        let mut keys_text = keys.join(", ");
+
         let CommandInfo {
             mut name,
             mut description,
-        } = keymap.command.get_info();
+        } = command.get_info();
 
         // Text wrapping
-        let name_width = (area.width - KEY_WIDTH) * NAME_PERC / 100;
-        let description_width = (area.width - KEY_WIDTH - MARGINE) * DESCRIPTION_PERC / 100;
+        let keys_width = (area.width - MARGINE) * KEY_PERC / 100;
+        let name_width = area.width * NAME_PERC / 100;
+        let description_width = (area.width - MARGINE) * DESCRIPTION_PERC / 100;
 
+        keys_text = textwrap::fill(keys_text.as_str(), keys_width as usize);
         name = textwrap::fill(name.as_str(), name_width as usize);
         description = textwrap::fill(description.as_str(), description_width as usize);
 
-        let height = name.lines().count().max(description.lines().count()) as u16;
+        let height = name
+            .lines()
+            .count()
+            .max(description.lines().count())
+            .max(keys_text.lines().count()) as u16;
 
         let cells = vec![
-            Cell::from(key).style(Style::default().add_modifier(Modifier::ITALIC)),
+            Cell::from(keys_text).style(Style::default().add_modifier(Modifier::ITALIC)),
             Cell::from(name),
             Cell::from(description),
         ];
@@ -58,7 +79,7 @@ pub fn render_help_popup<B: Backend>(
                 .borders(Borders::ALL),
         )
         .widths(&[
-            Constraint::Length(KEY_WIDTH),
+            Constraint::Percentage(KEY_PERC),
             Constraint::Percentage(NAME_PERC),
             Constraint::Percentage(DESCRIPTION_PERC),
         ]);

--- a/src/app/ui/help_popup.rs
+++ b/src/app/ui/help_popup.rs
@@ -2,9 +2,9 @@ use std::collections::BTreeMap;
 
 use tui::{
     backend::Backend,
-    layout::{Constraint, Rect},
+    layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
-    widgets::{Block, Borders, Cell, Clear, Row, Table},
+    widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, Wrap},
     Frame,
 };
 
@@ -17,6 +17,10 @@ const NAME_PERC: u16 = 27;
 const DESCRIPTION_PERC: u16 = 100 - NAME_PERC - KEY_PERC;
 const MARGINE: u16 = 8;
 
+const EDITOR_HINT_TEXT: &str = r"The Editor has two modes:
+ - Normal-Mode: In this mode VIM keybindings are used to navigate the text and to enter edit mode via (i, I, a , A, o, O).
+ - Edit-Mode: In this mode Emacs keybindings are used to edit and navigate the text.";
+
 pub fn render_help_popup<B: Backend>(
     frame: &mut Frame<B>,
     area: Rect,
@@ -24,6 +28,26 @@ pub fn render_help_popup<B: Backend>(
 ) {
     let area = centered_rect(90, 80, area);
 
+    let block = Block::default().title("Help").borders(Borders::ALL);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .horizontal_margin(2)
+        .vertical_margin(1)
+        .constraints([Constraint::Min(10), Constraint::Length(6)].as_ref())
+        .split(area);
+
+    frame.render_widget(Clear, area);
+    frame.render_widget(block, area);
+    render_keymaps_table(frame, chunks[0], ui_components);
+    render_editor_hint(frame, chunks[1]);
+}
+
+fn render_keymaps_table<B: Backend>(
+    frame: &mut Frame<B>,
+    area: Rect,
+    ui_components: &UIComponents,
+) {
     let header_cells = ["Key", "Command", "Description"]
         .into_iter()
         .map(|header| Cell::from(header).style(Style::default().fg(Color::LightBlue)));
@@ -75,7 +99,7 @@ pub fn render_help_popup<B: Backend>(
         .header(header)
         .block(
             Block::default()
-                .title("Help - Keybindigs")
+                .title("General Keybindings")
                 .borders(Borders::ALL),
         )
         .widths(&[
@@ -84,6 +108,17 @@ pub fn render_help_popup<B: Backend>(
             Constraint::Percentage(DESCRIPTION_PERC),
         ]);
 
-    frame.render_widget(Clear, area);
     frame.render_widget(keymaps_table, area);
+}
+
+pub fn render_editor_hint<B: Backend>(frame: &mut Frame<B>, area: Rect) {
+    let paragraph = Paragraph::new(EDITOR_HINT_TEXT)
+        .block(
+            Block::default()
+                .title("Editor Keybindings")
+                .borders(Borders::ALL),
+        )
+        .wrap(Wrap { trim: false });
+
+    frame.render_widget(paragraph, area);
 }


### PR DESCRIPTION
This PR fixes #12 

This PR adds the following improvements to the help popup:
1. Keybindings are grouped by commands to remove redundant commands infos in commands table
1. The popup will be divided into two sections: General keybindings and Editor keybindings
1. Editor keybindings section has a description about how VIM and Emacs keybindings are used in the editor