### PR TITLE
Added: Export current journal's content

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ TUI-Journal is a terminal-based application written in Rust that allows you to w
 - Keybindings is a combination of VIM and Emacs motions (VIM for navigation and Emacs for editing texts in edit-mode).
 - See the keybindings from inside the app
 - Cross-platform compatibility (Windows, macOS, Linux, NetBSD).
-- Export the current journal content to a predefined export order or the current directory 
+- Export the current journal's content to a predefined export path or the current directory 
 
 ## Roadmap
 
@@ -136,11 +136,11 @@ The configuration for TUI-Journal can be found in the `config.toml` file located
 Here is a sample of the default settings in the `config.toml` file:
 
 ```toml
-backend_type = "Sqlite"   # available options Json, Sqlite
+backend_type = "Sqlite"   # available options: Json, Sqlite. Default value: Sqlite.
 
 [export]
-default_path = "<Absolute_path_to_export_directory>"   # Optional default path to export journal content. Falls back to the current directory if not specified
-show_confirmation = true   # Show confirmation after successful export
+default_path = "<Absolute_path_to_export_directory>"   # Optional default path to export journal content. Falls back to the current directory if not specified.
+show_confirmation = true   # Show confirmation after successful export.
 
 [json_backend]
 file_path = "<Documents-folder>/tui-journal/entries.json"

--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ TUI-Journal is a terminal-based application written in Rust that allows you to w
 - Store your entries in either a plain text file using the JSON format or a SQLite database.
 - Intuitive, responsive and user-friendly text-based user interface (TUI).
 - Create, edit, and delete entries easily.
-- Keybindigs is a combination of VIM and Emacs motions (VIM for navigation and Emacs for editing texts in edit-mode).
+- Keybindings is a combination of VIM and Emacs motions (VIM for navigation and Emacs for editing texts in edit-mode).
 - See the keybindings from inside the app
 - Cross-platform compatibility (Windows, macOS, Linux, NetBSD).
+- Export the current journal content to a predefined export order or the current directory 
 
 ## Roadmap
 
@@ -135,7 +136,11 @@ The configuration for TUI-Journal can be found in the `config.toml` file located
 Here is a sample of the default settings in the `config.toml` file:
 
 ```toml
-backend_type = "Sqlite"
+backend_type = "Sqlite"   # available options Json, Sqlite
+
+[export]
+default_path = "<Absolute_path_to_export_directory>"   # Optional default path to export journal content. Falls back to the current directory if not specified
+show_confirmation = true   # Show confirmation after successful export
 
 [json_backend]
 file_path = "<Documents-folder>/tui-journal/entries.json"

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -163,6 +163,10 @@ pub fn get_entries_list_keymaps() -> Vec<Keymap> {
             Input::new(KeyCode::Char('d'), KeyModifiers::CONTROL),
             UICommand::DeleteCurrentEntry,
         ),
+        Keymap::new(
+            Input::new(KeyCode::Char('>'), KeyModifiers::NONE),
+            UICommand::ExportEntryContent,
+        ),
     ]
 }
 

--- a/src/app/ui/commands/entries_list_cmd.rs
+++ b/src/app/ui/commands/entries_list_cmd.rs
@@ -183,7 +183,7 @@ pub fn exec_export_entry_content<D: DataProvider>(
     app: &App<D>,
 ) -> CmdResult {
     if ui_components.has_unsaved() {
-        ui_components.show_unsaved_msg_box(Some(UICommand::CreateEntry));
+        ui_components.show_unsaved_msg_box(Some(UICommand::ExportEntryContent));
     } else {
         export_entry_content(ui_components, app);
     }

--- a/src/app/ui/commands/mod.rs
+++ b/src/app/ui/commands/mod.rs
@@ -30,6 +30,7 @@ pub enum UICommand {
     SaveEntryContent,
     DiscardChangesEntryContent,
     ReloadAll,
+    ExportEntryContent,
 }
 
 #[derive(Debug, Clone)]
@@ -91,6 +92,9 @@ impl UICommand {
                 CommandInfo::new("Discard changes", "Discard changes on journal content")
             }
             UICommand::ReloadAll => CommandInfo::new("Reload all", "Reload all entries"),
+            UICommand::ExportEntryContent => {
+                CommandInfo::new("Export journal content", "Export current journal content")
+            }
         }
     }
 
@@ -114,6 +118,7 @@ impl UICommand {
             UICommand::SaveEntryContent => exec_save_entry_content(ui_components, app).await,
             UICommand::DiscardChangesEntryContent => exec_discard_content(ui_components),
             UICommand::ReloadAll => exec_reload_all(ui_components, app).await,
+            UICommand::ExportEntryContent => exec_export_entry_content(ui_components, app),
         }
     }
 
@@ -149,6 +154,9 @@ impl UICommand {
                 continue_discard_content(ui_components, app, msg_box_result)
             }
             UICommand::ReloadAll => continue_reload_all(ui_components, app, msg_box_result).await,
+            UICommand::ExportEntryContent => {
+                continue_export_entry_content(ui_components, app, msg_box_result).await
+            }
         }
     }
 }

--- a/src/app/ui/entry_popup/mod.rs
+++ b/src/app/ui/entry_popup/mod.rs
@@ -14,7 +14,9 @@ use crate::app::{keymap::Input, App};
 
 use backend::{DataProvider, Entry};
 
-use super::{ui_functions::centered_rect_exact_height, ACTIVE_CONTROL_COLOR};
+use super::{
+    ui_functions::centered_rect_exact_height, ACTIVE_CONTROL_COLOR, INVALID_CONTROL_COLOR,
+};
 
 const FOOTER_TEXT: &str =
     "Enter: confirm | Tab: Change focused input box | Esc or <Ctrl-c>: Cancel";
@@ -148,7 +150,7 @@ impl<'a> EntryPopup<'a> {
                 .set_block(Block::default().borders(Borders::ALL).title("Title"));
         } else {
             self.title_txt
-                .set_style(Style::default().fg(Color::LightRed));
+                .set_style(Style::default().fg(INVALID_CONTROL_COLOR));
             self.title_txt.set_block(
                 Block::default()
                     .borders(Borders::ALL)
@@ -163,7 +165,7 @@ impl<'a> EntryPopup<'a> {
                 .set_block(Block::default().borders(Borders::ALL).title("Date"));
         } else {
             self.date_txt
-                .set_style(Style::default().fg(Color::LightRed));
+                .set_style(Style::default().fg(INVALID_CONTROL_COLOR));
             self.date_txt.set_block(
                 Block::default()
                     .borders(Borders::ALL)

--- a/src/app/ui/export_popup/mod.rs
+++ b/src/app/ui/export_popup/mod.rs
@@ -1,0 +1,173 @@
+use std::{env, path::PathBuf};
+
+use backend::{DataProvider, Entry};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use tui::{
+    backend::Backend,
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::Style,
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
+    Frame,
+};
+use tui_textarea::{CursorMove, TextArea};
+
+use crate::app::{keymap::Input, App};
+
+use super::{
+    ui_functions::centered_rect_exact_height, ACTIVE_CONTROL_COLOR, INVALID_CONTROL_COLOR,
+};
+
+const FOOTER_TEXT: &str = "Enter: confirm | Esc or <Ctrl-c>: Cancel";
+const FOOTER_MARGINE: u16 = 8;
+
+pub struct ExportPopup<'a> {
+    path_txt: TextArea<'a>,
+    path_err_msg: String,
+    entry_id: u32,
+    entry_title: String,
+}
+
+pub enum ExportPopupInputReturn {
+    KeepPopup,
+    Cancel,
+    Export(u32, PathBuf),
+}
+
+impl<'a> ExportPopup<'a> {
+    pub fn create<D: DataProvider>(entry: &Entry, app: &App<D>) -> anyhow::Result<Self> {
+        let mut default_path = if let Some(path) = &app.settings.export.default_path {
+            path.clone()
+        } else {
+            env::current_dir()?
+        };
+
+        // Add filename if it's not already defined
+        if default_path.extension().is_none() {
+            default_path.push(entry.title.as_str());
+            default_path.set_extension("txt");
+        }
+
+        let mut path_txt = TextArea::new(vec![default_path.to_string_lossy().to_string()]);
+        path_txt.move_cursor(CursorMove::End);
+
+        let mut export_popup = ExportPopup {
+            path_txt,
+            path_err_msg: String::default(),
+            entry_id: entry.id,
+            entry_title: entry.title.to_owned(),
+        };
+
+        export_popup.validate_path();
+
+        Ok(export_popup)
+    }
+
+    fn validate_path(&mut self) {
+        let path = self
+            .path_txt
+            .lines()
+            .first()
+            .expect("Path Textbox should always have one line");
+
+        if path.is_empty() {
+            self.path_err_msg = "Path can't be empty".into();
+        } else {
+            self.path_err_msg.clear();
+        }
+    }
+
+    fn is_input_valid(&self) -> bool {
+        self.path_err_msg.is_empty()
+    }
+
+    pub fn render_widget<B: Backend>(&mut self, frame: &mut Frame<B>, area: Rect) {
+        let mut area = centered_rect_exact_height(70, 11, area);
+
+        if area.width < FOOTER_TEXT.len() as u16 + FOOTER_MARGINE {
+            area.height += 1;
+        }
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title("Export journal content");
+
+        frame.render_widget(Clear, area);
+        frame.render_widget(block, area);
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .horizontal_margin(4)
+            .vertical_margin(2)
+            .constraints(
+                [
+                    Constraint::Length(2),
+                    Constraint::Length(3),
+                    Constraint::Length(1),
+                    Constraint::Min(1),
+                ]
+                .as_ref(),
+            )
+            .split(area);
+
+        let journal_para_text = format!("Journal: {}", self.entry_title);
+        let journal_paragraph = Paragraph::new(journal_para_text).wrap(Wrap { trim: false });
+        frame.render_widget(journal_paragraph, chunks[0]);
+
+        if self.path_err_msg.is_empty() {
+            self.path_txt
+                .set_style(Style::default().fg(ACTIVE_CONTROL_COLOR));
+            self.path_txt
+                .set_block(Block::default().borders(Borders::ALL).title("Path"));
+        } else {
+            self.path_txt
+                .set_style(Style::default().fg(INVALID_CONTROL_COLOR));
+            self.path_txt.set_block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(format!("Path : {}", self.path_err_msg)),
+            );
+        }
+
+        self.path_txt.set_cursor_line_style(Style::default());
+
+        frame.render_widget(self.path_txt.widget(), chunks[1]);
+
+        let footer = Paragraph::new(FOOTER_TEXT)
+            .alignment(Alignment::Center)
+            .wrap(Wrap { trim: false });
+
+        frame.render_widget(footer, chunks[3]);
+    }
+
+    pub fn handle_input(&mut self, input: &Input) -> ExportPopupInputReturn {
+        let has_ctrl = input.modifiers.contains(KeyModifiers::CONTROL);
+        match input.key_code {
+            KeyCode::Esc => ExportPopupInputReturn::Cancel,
+            KeyCode::Char('c') if has_ctrl => ExportPopupInputReturn::Cancel,
+            KeyCode::Enter => self.handle_confirm(),
+            _ => {
+                if self.path_txt.input(KeyEvent::from(input)) {
+                    self.validate_path();
+                }
+                ExportPopupInputReturn::KeepPopup
+            }
+        }
+    }
+
+    fn handle_confirm(&mut self) -> ExportPopupInputReturn {
+        self.validate_path();
+        if !self.is_input_valid() {
+            return ExportPopupInputReturn::KeepPopup;
+        }
+
+        let path: PathBuf = self
+            .path_txt
+            .lines()
+            .first()
+            .expect("Path Textbox should always have one line")
+            .parse()
+            .expect("PathBuf from string should never fail");
+
+        ExportPopupInputReturn::Export(self.entry_id, path)
+    }
+}

--- a/src/settings/export.rs
+++ b/src/settings/export.rs
@@ -5,9 +5,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ExportSettings {
     #[serde(default)]
-    default_path: Option<PathBuf>,
+    pub default_path: Option<PathBuf>,
     #[serde(default)]
-    show_confirmation: bool,
+    pub show_confirmation: bool,
 }
 
 impl Default for ExportSettings {

--- a/src/settings/export.rs
+++ b/src/settings/export.rs
@@ -1,0 +1,20 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ExportSettings {
+    #[serde(default)]
+    default_path: Option<PathBuf>,
+    #[serde(default)]
+    show_confirmation: bool,
+}
+
+impl Default for ExportSettings {
+    fn default() -> Self {
+        Self {
+            default_path: None,
+            show_confirmation: true,
+        }
+    }
+}

--- a/src/settings/export.rs
+++ b/src/settings/export.rs
@@ -6,8 +6,12 @@ use serde::{Deserialize, Serialize};
 pub struct ExportSettings {
     #[serde(default)]
     pub default_path: Option<PathBuf>,
-    #[serde(default)]
+    #[serde(default = "reutrn_true")]
     pub show_confirmation: bool,
+}
+
+fn reutrn_true() -> bool {
+    true
 }
 
 impl Default for ExportSettings {

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -23,7 +23,7 @@ pub struct Settings {
     #[serde(default)]
     pub export: ExportSettings,
     #[serde(default)]
-    pub backend_type: BackendType,
+    pub backend_type: Option<BackendType>,
     #[cfg(feature = "json")]
     #[serde(default)]
     pub json_backend: JsonBackend,
@@ -38,15 +38,6 @@ pub enum BackendType {
     Json,
     #[cfg_attr(feature = "sqlite", default)]
     Sqlite,
-}
-
-impl Default for BackendType {
-    fn default() -> Self {
-        #[cfg(all(feature = "json", not(feature = "sqlite")))]
-        return BackendType::Json;
-        #[cfg(feature = "sqlite")]
-        BackendType::Sqlite
-    }
 }
 
 impl Settings {
@@ -91,6 +82,7 @@ impl Settings {
             backend_type: _,
             json_backend: _,
             sqlite_backend: _,
+            export: _,
         } = self;
 
         if self.backend_type.is_none() {

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -16,10 +16,13 @@ pub mod json_backend;
 #[cfg(feature = "sqlite")]
 pub mod sqlite_backend;
 
+mod export;
+
 #[derive(Debug, Deserialize, Serialize, Default)]
 pub struct Settings {
     #[serde(default)]
     pub export: ExportSettings,
+    #[serde(default)]
     pub backend_type: BackendType,
     #[cfg(feature = "json")]
     #[serde(default)]
@@ -35,6 +38,15 @@ pub enum BackendType {
     Json,
     #[cfg_attr(feature = "sqlite", default)]
     Sqlite,
+}
+
+impl Default for BackendType {
+    fn default() -> Self {
+        #[cfg(all(feature = "json", not(feature = "sqlite")))]
+        return BackendType::Json;
+        #[cfg(feature = "sqlite")]
+        BackendType::Sqlite
+    }
 }
 
 impl Settings {

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -5,6 +5,7 @@ use clap::ValueEnum;
 use directories::{BaseDirs, UserDirs};
 use serde::{Deserialize, Serialize};
 
+use self::export::ExportSettings;
 #[cfg(feature = "json")]
 use self::json_backend::{get_default_json_path, JsonBackend};
 #[cfg(feature = "sqlite")]
@@ -18,7 +19,8 @@ pub mod sqlite_backend;
 #[derive(Debug, Deserialize, Serialize, Default)]
 pub struct Settings {
     #[serde(default)]
-    pub backend_type: Option<BackendType>,
+    pub export: ExportSettings,
+    pub backend_type: BackendType,
     #[cfg(feature = "json")]
     #[serde(default)]
     pub json_backend: JsonBackend,


### PR DESCRIPTION
The PR closes #6 

It adds a new function to export the content of the current journal to a file

### Workflow:
- While journals' list is in focus pressing `>` opens an export prompt
- In the export prompt the user can specify the path of the export file
- When the prompt is opened, a suggested path will be given: this suggestion is either a predefined path or the current directory as fall back + journal title
- After the export, an optional confirmation prompt  is shown

### Configurations:
This PR adds an export section with the following settings:
- default_path: The base path that will be shown in the export prompt. If not specified then it will falls back to the current directory
- show_confirmation: Sets if to show the confirmation prompt after the export is done. Default is true 