### PR TITLE
Fixed: Export journal extension

### DIFF
--- a/src/app/ui/export_popup/mod.rs
+++ b/src/app/ui/export_popup/mod.rs
@@ -43,8 +43,7 @@ impl<'a> ExportPopup<'a> {
 
         // Add filename if it's not already defined
         if default_path.extension().is_none() {
-            default_path.push(entry.title.as_str());
-            default_path.set_extension("txt");
+            default_path.push(format!("{}.txt", entry.title.as_str()));
         }
 
         let mut path_txt = TextArea::new(vec![default_path.to_string_lossy().to_string()]);


### PR DESCRIPTION
This PR closes #23 

Now the extension will be simply added to the end of the title name instead of using the method set_extension since it replaces what appears to be an extension in the title name