### PR TITLE
Added:  CITATION.cff

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Check sqlite
       run: cargo check --no-default-features -F sqlite --verbose
- 
+
     - name: Clippy
       run: cargo clippy
 
@@ -34,3 +34,13 @@ jobs:
 
     - name: Run tests
       run: cargo test --verbose
+
+  cffconvert:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - uses: citation-file-format/cffconvert-github-action@2.0.0
+        with:
+          args: --validate

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,8 +10,8 @@ version: 0.1.3
 abstract: Your journal app if you live in a terminl
 authors:
   - alias: AmmarAbouZor
-    family-names: Zor
-    given-names: Ammar Abou
+    family-names: Abou Zor
+    given-names: Ammar
 license:
   - MIT
 repository-artifact: https://crates.io/crates/tui-journal

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,20 @@
+# Parser settings.
+cff-version: 1.2.0
+message: Please cite this software using these information.
+
+# Version information.
+date-released: 2023-05-30
+version: 0.1.3
+
+# Project information.
+abstract: Your journal app if you live in a terminl
+authors:
+  - alias: AmmarAbouZor
+    family-names: Zor
+    given-names: Ammar Abou
+license:
+  - MIT
+repository-artifact: https://crates.io/crates/tui-journal
+repository-code: https://github.com/AmmarAbouZor/tui-journal
+title: TUI-Journal
+url: https://docs.rs/tui-journal


### PR DESCRIPTION
This PR adds a CITATION.cff as well as the corresponding validation step.

CFF is a technology to make software citable such that it can be added to a paper's or presentation's list of references just like a book or an article.  GitHub will render a "Cite this repository" blob on the repository's main page such that visitors can add TUI-Journal to their lists of references.  This can be seen as free advertisement as the software will thus become known to other people.  The validation usually takes only about 10 seconds, so it is not going to have any major impact on the CI's performance and runtime.

I am going to give a presentation on CHANGELOG management strategies next week; in the section on advanced fragment policies, I would like to mention the planned strategy for TUI-Journal (#16).  Therefore, I need to know how to cite this project.  Aeruginous now has all necessary features implemented required for completing #16, and I am about to release the next stable version containing the last functionalities today when I finished testing them.  As soon as the release is published, I will adjust the PR for the CHANGELOG setup according to the changes we already have agreed on such that you will have access to the fragment creation.

Please have a look at the citation metadata and check whether all information are correct.  We can add further integrations for self-maintenance of the CFF file in a subsequent PR.