### PR TITLE
Changed: Enhance render loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,7 @@ checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
+ "futures-core",
  "libc",
  "mio",
  "parking_lot 0.12.1",
@@ -1577,6 +1578,7 @@ dependencies = [
  "clap",
  "crossterm",
  "directories",
+ "futures-util",
  "log",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,14 @@ log = "0.4.17"
 chrono = { version = "0.4.24", features = ["serde"] }
 async-trait = "0.1.68"
 clap = { version = "4.2.4", features = ["derive"] }
-crossterm = "0.25"
+crossterm = {version =  "0.25", features = ["event-stream"]}
 directories = "5.0.0"
 simplelog = "0.12.1"
 textwrap = "0.16.0"
 thiserror = "1.0.40"
 toml = "0.7.3"
 sqlx = {version = "0.6.3", features = ["runtime-tokio-native-tls", "sqlite", "chrono"], optional = true}
+futures-util = { version = "0.3", default-features = false }
 
 # TODO: follow issue link: https://github.com/rhysd/tui-textarea/issues/19 and reapplay the migration
 tui = "0.19"

--- a/src/app/runner.rs
+++ b/src/app/runner.rs
@@ -1,11 +1,10 @@
-use std::time::{Duration, Instant};
-
-use anyhow::Result;
-use crossterm::event::Event;
+use anyhow::{Context, Result};
+use crossterm::event::{Event, EventStream};
 use tui::{backend::Backend, Terminal};
 
 use crate::app::{App, UIComponents};
 use crate::settings::{BackendType, Settings};
+use futures_util::{FutureExt, StreamExt};
 
 use backend::DataProvider;
 #[cfg(feature = "json")]
@@ -22,11 +21,7 @@ pub enum HandleInputReturnType {
     ExitApp,
 }
 
-pub async fn run<B: Backend>(
-    terminal: &mut Terminal<B>,
-    settings: Settings,
-    tick_rate: Duration,
-) -> Result<()> {
+pub async fn run<B: Backend>(terminal: &mut Terminal<B>, settings: Settings) -> Result<()> {
     match settings.backend_type.unwrap_or_default() {
         #[cfg(feature = "json")]
         BackendType::Json => {
@@ -36,7 +31,7 @@ pub async fn run<B: Backend>(
                 crate::settings::json_backend::get_default_json_path()?
             };
             let data_provider = JsonDataProvide::new(path);
-            run_intern(terminal, tick_rate, data_provider, settings).await
+            run_intern(terminal, data_provider, settings).await
         }
         #[cfg(not(feature = "json"))]
         BackendType::Json => {
@@ -52,7 +47,7 @@ pub async fn run<B: Backend>(
                 crate::settings::sqlite_backend::get_default_sqlite_path()?
             };
             let data_provider = SqliteDataProvide::from_file(path).await?;
-            run_intern(terminal, tick_rate, data_provider, settings).await
+            run_intern(terminal, data_provider, settings).await
         }
         #[cfg(not(feature = "sqlite"))]
         BackendType::Sqlite => {
@@ -65,7 +60,6 @@ pub async fn run<B: Backend>(
 
 async fn run_intern<B, D>(
     terminal: &mut Terminal<B>,
-    tick_rate: Duration,
     data_provider: D,
     settings: Settings,
 ) -> anyhow::Result<()>
@@ -73,7 +67,6 @@ where
     B: Backend,
     D: DataProvider,
 {
-    let mut last_tick = Instant::now();
     let mut ui_components = UIComponents::new();
     let mut app = App::new(data_provider, settings);
     if let Err(err) = app.load_entries().await {
@@ -82,40 +75,40 @@ where
 
     ui_components.set_current_entry(app.entries.first().map(|entry| entry.id), &mut app);
 
+    terminal.draw(|f| ui_components.render_ui(f, &app))?;
+
+    let mut intput_stream = EventStream::new();
     loop {
-        terminal.draw(|f| ui_components.render_ui(f, &app))?;
+        tokio::select! {
+            biased;
 
-        let timeout = tick_rate
-            .checked_sub(last_tick.elapsed())
-            .unwrap_or_else(|| Duration::from_secs(0));
-
-        if crossterm::event::poll(timeout)? {
-            if let Event::Key(key) = crossterm::event::read()? {
-                match handle_input(key, &mut app, &mut ui_components).await {
-                    Ok(return_type) => {
-                        if return_type == HandleInputReturnType::ExitApp {
-                            return Ok(());
-                        }
-                    }
-                    Err(err) => {
-                        ui_components.show_err_msg(err.to_string());
-                    }
+            input =  intput_stream.next().fuse() => {
+                match input {
+                    Some(event) => {
+                        let event = event.context("Error gettig input stream")?;
+                       let result = handle_input(event, &mut app, &mut ui_components).await?;
+                        match result {
+                            HandleInputReturnType::Handled | HandleInputReturnType::NotFound => terminal.draw(|f| ui_components.render_ui(f, &app))?,
+                            HandleInputReturnType::ExitApp => return Ok(()),
+                        };
+                    },
+                    None => return Ok(()),
                 }
-            }
-        }
-
-        if last_tick.elapsed() >= tick_rate {
-            last_tick = Instant::now();
+            },
         }
     }
 }
 
 async fn handle_input<'a, D: DataProvider>(
-    key: crossterm::event::KeyEvent,
+    event: Event,
     app: &mut App<D>,
     ui_components: &mut UIComponents<'a>,
 ) -> Result<HandleInputReturnType> {
-    let input = Input::from(&key);
+    if let Event::Key(key) = event {
+        let input = Input::from(&key);
 
-    ui_components.handle_input(&input, app).await
+        ui_components.handle_input(&input, app).await
+    } else {
+        Ok(HandleInputReturnType::NotFound)
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{io, time::Duration};
+use std::io;
 
 use anyhow::Result;
 use clap::Parser;
@@ -34,13 +34,10 @@ async fn main() -> Result<()> {
 
     chain_panic_hook();
 
-    let tick_rate = Duration::from_millis(250);
-    app::run(&mut terminal, settings, tick_rate)
-        .await
-        .map_err(|err| {
-            log::error!("[PANIC] {}", err.to_string());
-            err
-        })?;
+    app::run(&mut terminal, settings).await.map_err(|err| {
+        log::error!("[PANIC] {}", err.to_string());
+        err
+    })?;
 
     // restore terminal
     disable_raw_mode()?;


### PR DESCRIPTION
This PR brings the following enhancements to the app render loop:

- Changes the render loop using event-stream from crossterm, since the recommended way to run in tokio runtime 
- Remove unnecessary rendering on tick rate since the app doesn't monitor anything outside the user input