### PR TITLE
Added: Edit current journal content in external editor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,6 +1580,7 @@ dependencies = [
  "directories",
  "futures-util",
  "log",
+ "scopeguard",
  "serde",
  "serde_json",
  "simplelog",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ futures-util = { version = "0.3", default-features = false }
 # TODO: follow issue link: https://github.com/rhysd/tui-textarea/issues/19 and reapplay the migration
 tui = "0.19"
 tui-textarea = "0.2"
+scopeguard = "1.1.0"
 # Textarea crate supports ratatui but it doesn't provide a new version on crates.io to support it
 # crossterm = "0.26"
 # tui = { version = "0.20", package = "ratatui" }

--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ TUI-Journal is a terminal-based application written in Rust that allows you to w
 - Store your entries in either a plain text file using the JSON format or a SQLite database.
 - Intuitive, responsive and user-friendly text-based user interface (TUI).
 - Create, edit, and delete entries easily.
-- Keybindings is a combination of VIM and Emacs motions (VIM for navigation and Emacs for editing texts in edit-mode).
+- Edit journal content with the built-in editor or use your favourite terminal text editor from withing the app.
 - See the keybindings from inside the app
-- Cross-platform compatibility (Windows, macOS, Linux, NetBSD).
+- Keybindings is a combination of VIM and Emacs motions (VIM for navigation and Emacs for editing texts in edit-mode).
 - Export the current journal's content to a predefined export path or the current directory 
+- Cross-platform compatibility (Windows, macOS, Linux, NetBSD).
 
 ## Roadmap
 
@@ -46,8 +47,9 @@ TUI-Journal is a terminal-based application written in Rust that allows you to w
 - [x]  Database back-end using SQLite.
 - [ ]  RESTful back-end server with a client in the app.
 #### Application:
+- [x]  Edit journals content with external text editor from withing the app.
+- [ ]  Filter & Search functionalities.
 - [ ]  Customize themes and keybindings.
-- [ ]  Search functionality.
 - [ ]  Load entries as chunks for better performance.
 ## Installation
 
@@ -75,6 +77,12 @@ To install TUI-Journal with default features (SQLite and JSON), you can use `car
 cargo install tui-journal
 ```
 
+#### Install nightly version:
+To use the current nightly version, you can install it directly from the GitHub repository
+
+```bash
+cargo install --git https://github.com/ammarabouzor/tui-journal
+```
 
 #### Install with Specific Features:
 
@@ -133,10 +141,12 @@ Options:
 
 The configuration for TUI-Journal can be found in the `config.toml` file located in the configuration folder within the TUI-Journal directory.
 
-Here is a sample of the default settings in the `config.toml` file:
+Here is a sample of the settings in the `config.toml` file:
 
 ```toml
 backend_type = "Sqlite"   # available options: Json, Sqlite. Default value: Sqlite.
+# Set the external terminal editor to use from withing the app. If the value isn't set the app will use the environment varialbes VISUAL, EDITOR then it'll try with vi.  
+external_editor = "nvim"
 
 [export]
 default_path = "<Absolute_path_to_export_directory>"   # Optional default path to export journal content. Falls back to the current directory if not specified.

--- a/src/app/external_editor.rs
+++ b/src/app/external_editor.rs
@@ -1,0 +1,71 @@
+use std::{env, ffi::OsStr, io, path::Path};
+
+use anyhow::{bail, Context};
+
+use crossterm::{
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen},
+    ExecutableCommand,
+};
+use scopeguard::defer;
+use tokio::process::Command;
+
+use crate::settings::Settings;
+
+const ENV_EDITOR_OPTIONS: [&str; 2] = ["VISUAL", "EDITOR"];
+
+pub async fn open_editor(file_path: &Path, settings: &Settings) -> anyhow::Result<()> {
+    if !file_path.exists() {
+        bail!("file doesn't exist: {}", file_path.display());
+    }
+
+    let file_path = file_path.canonicalize()?;
+
+    let editor_raw = settings
+        .external_editor
+        .as_ref()
+        .cloned()
+        .or_else(|| env::var(ENV_EDITOR_OPTIONS[0]).ok())
+        .or_else(|| env::var(ENV_EDITOR_OPTIONS[1]).ok())
+        .unwrap_or(String::from("vi"));
+
+    if editor_raw.is_empty() {
+        bail!(
+            "The Editor in configuration and environmental variables is empty: {}",
+            ENV_EDITOR_OPTIONS.join(" - ")
+        );
+    }
+
+    let mut editor_chars = editor_raw.chars().peekable();
+
+    let start_char = editor_chars
+        .peek()
+        .expect("Editor name can't be empty")
+        .to_owned();
+
+    let editor_cmd: String = match start_char {
+        '\"' => editor_chars
+            .by_ref()
+            .skip(1)
+            .take_while(|&c| c != '\"')
+            .collect(),
+        _ => editor_chars.by_ref().take_while(|&c| c != ' ').collect(),
+    };
+
+    let rest_args: String = editor_chars.collect();
+    let mut args: Vec<&OsStr> = rest_args.split_whitespace().map(OsStr::new).collect();
+
+    args.push(file_path.as_os_str());
+
+    io::stdout().execute(LeaveAlternateScreen)?;
+    defer! {
+        io::stdout().execute(EnterAlternateScreen).unwrap();
+    }
+
+    Command::new(editor_cmd)
+        .args(args)
+        .status()
+        .await
+        .context("Error while openning the editor")?;
+
+    Ok(())
+}

--- a/src/app/external_editor.rs
+++ b/src/app/external_editor.rs
@@ -67,7 +67,7 @@ pub async fn open_editor(file_path: &Path, settings: &Settings) -> anyhow::Resul
         .await
         .map_err(|err| {
             anyhow!(
-                "Error while openning the editor. Editor command: '{}'. Error: {}",
+                "Error while opening the editor. Editor command: '{}'. Error: {}",
                 editor_cmd,
                 err
             )

--- a/src/app/external_editor.rs
+++ b/src/app/external_editor.rs
@@ -1,6 +1,6 @@
 use std::{env, ffi::OsStr, io, path::Path};
 
-use anyhow::{bail, Context};
+use anyhow::{anyhow, bail};
 
 use crossterm::{
     terminal::{EnterAlternateScreen, LeaveAlternateScreen},
@@ -61,11 +61,17 @@ pub async fn open_editor(file_path: &Path, settings: &Settings) -> anyhow::Resul
         io::stdout().execute(EnterAlternateScreen).unwrap();
     }
 
-    Command::new(editor_cmd)
+    Command::new(editor_cmd.clone())
         .args(args)
         .status()
         .await
-        .context("Error while openning the editor")?;
+        .map_err(|err| {
+            anyhow!(
+                "Error while openning the editor. Editor command: '{}'. Error: {}",
+                editor_cmd,
+                err
+            )
+        })?;
 
     Ok(())
 }

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -164,6 +164,10 @@ pub fn get_entries_list_keymaps() -> Vec<Keymap> {
             UICommand::DeleteCurrentEntry,
         ),
         Keymap::new(
+            Input::new(KeyCode::Char('d'), KeyModifiers::NONE),
+            UICommand::DeleteCurrentEntry,
+        ),
+        Keymap::new(
             Input::new(KeyCode::Char('d'), KeyModifiers::CONTROL),
             UICommand::DeleteCurrentEntry,
         ),

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -167,6 +167,10 @@ pub fn get_entries_list_keymaps() -> Vec<Keymap> {
             Input::new(KeyCode::Char('>'), KeyModifiers::NONE),
             UICommand::ExportEntryContent,
         ),
+        Keymap::new(
+            Input::new(KeyCode::Char('v'), KeyModifiers::CONTROL),
+            UICommand::EditInExternalEditor,
+        ),
     ]
 }
 

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -126,6 +126,10 @@ pub(crate) fn get_global_keymaps() -> Vec<Keymap> {
             Input::new(KeyCode::Char('r'), KeyModifiers::CONTROL),
             UICommand::ReloadAll,
         ),
+        Keymap::new(
+            Input::new(KeyCode::Char('v'), KeyModifiers::CONTROL),
+            UICommand::EditInExternalEditor,
+        ),
     ]
 }
 
@@ -168,7 +172,7 @@ pub fn get_entries_list_keymaps() -> Vec<Keymap> {
             UICommand::ExportEntryContent,
         ),
         Keymap::new(
-            Input::new(KeyCode::Char('v'), KeyModifiers::CONTROL),
+            Input::new(KeyCode::Char('v'), KeyModifiers::NONE),
             UICommand::EditInExternalEditor,
         ),
     ]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -7,6 +7,7 @@ use chrono::{DateTime, Utc};
 pub use runner::run;
 pub use ui::UIComponents;
 
+mod external_editor;
 mod keymap;
 mod runner;
 mod ui;
@@ -23,7 +24,7 @@ where
     pub entries: Vec<Entry>,
     pub current_entry_id: Option<u32>,
     pub settings: Settings,
-    pub redraw_after_minimize: bool,
+    pub redraw_after_restore: bool,
 }
 
 impl<D> App<D>
@@ -37,7 +38,7 @@ where
             entries,
             current_entry_id: None,
             settings,
-            redraw_after_minimize: false,
+            redraw_after_restore: false,
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -23,6 +23,7 @@ where
     pub entries: Vec<Entry>,
     pub current_entry_id: Option<u32>,
     pub settings: Settings,
+    pub redraw_after_minimize: bool,
 }
 
 impl<D> App<D>
@@ -36,6 +37,7 @@ where
             entries,
             current_entry_id: None,
             settings,
+            redraw_after_minimize: false,
         }
     }
 

--- a/src/app/runner.rs
+++ b/src/app/runner.rs
@@ -106,8 +106,8 @@ fn draw_ui<'a, B: Backend, D: DataProvider>(
     app: &mut App<D>,
     ui_components: &mut UIComponents<'a>,
 ) -> anyhow::Result<()> {
-    if app.redraw_after_minimize {
-        app.redraw_after_minimize = false;
+    if app.redraw_after_restore {
+        app.redraw_after_restore = false;
         // Apply hide cursor again after closing the external editor
         terminal.hide_cursor()?;
         // Resize forces the terminal to redraw everything

--- a/src/app/runner.rs
+++ b/src/app/runner.rs
@@ -77,12 +77,12 @@ where
 
     draw_ui(terminal, &mut app, &mut ui_components)?;
 
-    let mut intput_stream = EventStream::new();
+    let mut input_stream = EventStream::new();
     loop {
         tokio::select! {
             biased;
 
-            input =  intput_stream.next().fuse() => {
+            input =  input_stream.next().fuse() => {
                 match input {
                     Some(event) => {
                         let event = event.context("Error gettig input stream")?;

--- a/src/app/runner.rs
+++ b/src/app/runner.rs
@@ -86,13 +86,20 @@ where
                 match input {
                     Some(event) => {
                         let event = event.context("Error gettig input stream")?;
-                        let result = handle_input(event, &mut app, &mut ui_components).await?;
-                        match result {
-                            HandleInputReturnType::Handled | HandleInputReturnType::NotFound =>{
-                                draw_ui(terminal, &mut app, &mut ui_components)?;
+                        match handle_input(event, &mut app, &mut ui_components).await{
+                            Ok(result) => {
+                                match result {
+                                    HandleInputReturnType::Handled | HandleInputReturnType::NotFound =>{
+                                        draw_ui(terminal, &mut app, &mut ui_components)?;
+                                    },
+                                    HandleInputReturnType::ExitApp => return Ok(()),
+                                };
                             },
-                            HandleInputReturnType::ExitApp => return Ok(()),
-                        };
+                            Err(err) => {
+                                ui_components.show_err_msg(err.to_string());
+                                draw_ui(terminal, &mut app, &mut ui_components)?;
+                            }
+                        }
                     },
                     None => return Ok(()),
                 }

--- a/src/app/runner.rs
+++ b/src/app/runner.rs
@@ -101,10 +101,10 @@ where
     }
 }
 
-fn draw_ui<'a, B: Backend, D: DataProvider>(
+fn draw_ui<B: Backend, D: DataProvider>(
     terminal: &mut Terminal<B>,
     app: &mut App<D>,
-    ui_components: &mut UIComponents<'a>,
+    ui_components: &mut UIComponents,
 ) -> anyhow::Result<()> {
     if app.redraw_after_restore {
         app.redraw_after_restore = false;
@@ -114,7 +114,7 @@ fn draw_ui<'a, B: Backend, D: DataProvider>(
         terminal.resize(terminal.size()?)?;
     }
 
-    terminal.draw(|f| ui_components.render_ui(f, &app))?;
+    terminal.draw(|f| ui_components.render_ui(f, app))?;
 
     Ok(())
 }

--- a/src/app/ui/commands/entries_list_cmd.rs
+++ b/src/app/ui/commands/entries_list_cmd.rs
@@ -236,7 +236,7 @@ pub async fn exec_edit_in_external_editor<'a, D: DataProvider>(
     app: &mut App<D>,
 ) -> CmdResult {
     if ui_components.has_unsaved() {
-        ui_components.show_unsaved_msg_box(Some(UICommand::ExportEntryContent));
+        ui_components.show_unsaved_msg_box(Some(UICommand::EditInExternalEditor));
     } else {
         edit_in_external_editor(ui_components, app).await?;
     }

--- a/src/app/ui/commands/entries_list_cmd.rs
+++ b/src/app/ui/commands/entries_list_cmd.rs
@@ -268,9 +268,9 @@ pub async fn edit_in_external_editor<'a, D: DataProvider>(
         std::fs::remove_file(&file_path).expect("Temp File couldn't be deleted");
         }
 
-        external_editor::open_editor(&file_path, &app.settings).await?;
-
         app.redraw_after_restore = true;
+
+        external_editor::open_editor(&file_path, &app.settings).await?;
 
         if file_path.exists() {
             let new_content = fs::read_to_string(&file_path).await?;

--- a/src/app/ui/commands/entries_list_cmd.rs
+++ b/src/app/ui/commands/entries_list_cmd.rs
@@ -274,10 +274,8 @@ pub async fn edit_in_external_editor<'a, D: DataProvider>(
 
         if file_path.exists() {
             let new_content = fs::read_to_string(&file_path).await?;
-            let entry_id = entry.id;
-            app.update_current_entry_content(new_content).await?;
-
-            ui_components.editor.set_current_entry(Some(entry_id), app);
+            ui_components.editor.set_entry_content(&new_content, app);
+            ui_components.change_active_control(ControlType::EntryContentTxt);
         }
     }
 

--- a/src/app/ui/commands/mod.rs
+++ b/src/app/ui/commands/mod.rs
@@ -124,7 +124,9 @@ impl UICommand {
             UICommand::DiscardChangesEntryContent => exec_discard_content(ui_components),
             UICommand::ReloadAll => exec_reload_all(ui_components, app).await,
             UICommand::ExportEntryContent => exec_export_entry_content(ui_components, app),
-            UICommand::EditInExternalEditor => exec_edit_in_external_editor(ui_components, app),
+            UICommand::EditInExternalEditor => {
+                exec_edit_in_external_editor(ui_components, app).await
+            }
         }
     }
 

--- a/src/app/ui/commands/mod.rs
+++ b/src/app/ui/commands/mod.rs
@@ -98,7 +98,7 @@ impl UICommand {
             }
             UICommand::EditInExternalEditor => CommandInfo::new(
                 "Edit in external editor",
-                "Edit current journal content in external editor",
+                "Edit current journal content in external editor (The editor can be set in configurations file or via the environment variables VISUAL, EDITOR)",
             ),
         }
     }

--- a/src/app/ui/commands/mod.rs
+++ b/src/app/ui/commands/mod.rs
@@ -31,6 +31,7 @@ pub enum UICommand {
     DiscardChangesEntryContent,
     ReloadAll,
     ExportEntryContent,
+    EditInExternalEditor,
 }
 
 #[derive(Debug, Clone)]
@@ -95,6 +96,10 @@ impl UICommand {
             UICommand::ExportEntryContent => {
                 CommandInfo::new("Export journal content", "Export current journal content")
             }
+            UICommand::EditInExternalEditor => CommandInfo::new(
+                "Edit in external editor",
+                "Edit current journal content in external editor",
+            ),
         }
     }
 
@@ -119,6 +124,7 @@ impl UICommand {
             UICommand::DiscardChangesEntryContent => exec_discard_content(ui_components),
             UICommand::ReloadAll => exec_reload_all(ui_components, app).await,
             UICommand::ExportEntryContent => exec_export_entry_content(ui_components, app),
+            UICommand::EditInExternalEditor => exec_edit_in_external_editor(ui_components, app),
         }
     }
 
@@ -156,6 +162,9 @@ impl UICommand {
             UICommand::ReloadAll => continue_reload_all(ui_components, app, msg_box_result).await,
             UICommand::ExportEntryContent => {
                 continue_export_entry_content(ui_components, app, msg_box_result).await
+            }
+            UICommand::EditInExternalEditor => {
+                continue_edit_in_external_editor(ui_components, app, msg_box_result).await
             }
         }
     }

--- a/src/app/ui/editor/mod.rs
+++ b/src/app/ui/editor/mod.rs
@@ -269,6 +269,18 @@ impl<'a> Editor<'a> {
             false => false,
         }
     }
+
+    pub fn set_entry_content<D: DataProvider>(&mut self, entry_content: &str, app: &App<D>) {
+        self.is_dirty = true;
+        let lines = entry_content.lines().map(|line| line.to_owned()).collect();
+        let mut text_area = TextArea::new(lines);
+        text_area.move_cursor(tui_textarea::CursorMove::Bottom);
+        text_area.move_cursor(tui_textarea::CursorMove::End);
+
+        self.text_area = text_area;
+
+        self.refresh_has_unsaved(app);
+    }
 }
 
 #[inline]

--- a/src/settings/export.rs
+++ b/src/settings/export.rs
@@ -6,11 +6,11 @@ use serde::{Deserialize, Serialize};
 pub struct ExportSettings {
     #[serde(default)]
     pub default_path: Option<PathBuf>,
-    #[serde(default = "reutrn_true")]
+    #[serde(default = "return_true")]
     pub show_confirmation: bool,
 }
 
-fn reutrn_true() -> bool {
+fn return_true() -> bool {
     true
 }
 

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -24,6 +24,8 @@ pub struct Settings {
     pub export: ExportSettings,
     #[serde(default)]
     pub backend_type: Option<BackendType>,
+    #[serde(default)]
+    pub external_editor: Option<String>,
     #[cfg(feature = "json")]
     #[serde(default)]
     pub json_backend: JsonBackend,
@@ -83,6 +85,7 @@ impl Settings {
             json_backend: _,
             sqlite_backend: _,
             export: _,
+            external_editor: _,
         } = self;
 
         if self.backend_type.is_none() {


### PR DESCRIPTION
This PR closes #8

- It adds the function to edit the current journal content with an external terminal editor.
- Keybindings are v and <Ctrl-v>
- The editor can be set in the configurations. Config name is 'external_editor'
- If it's not set in the configs then the environment variables VISUAL, EDITOR will be used 