### PR TITLE
Added: Multi-selection for journals

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ TUI-Journal is a terminal-based application written in Rust that allows you to w
 - Intuitive, responsive and user-friendly text-based user interface (TUI).
 - Create, edit, and delete entries easily.
 - Edit journal content with the built-in editor or use your favourite terminal text editor from withing the app.
+- Control many journals at once via the multi-select mode
 - See the keybindings from inside the app
 - Keybindings is a combination of VIM and Emacs motions (VIM for navigation and Emacs for editing texts in edit-mode).
 - Export the current journal's content to a predefined export path or the current directory 

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -179,6 +179,10 @@ pub fn get_entries_list_keymaps() -> Vec<Keymap> {
             Input::new(KeyCode::Char('y'), KeyModifiers::NONE),
             UICommand::EditInExternalEditor,
         ),
+        Keymap::new(
+            Input::new(KeyCode::Char('v'), KeyModifiers::NONE),
+            UICommand::EnterMultiSelectMode,
+        ),
     ]
 }
 
@@ -203,6 +207,47 @@ pub(crate) fn get_editor_mode_keymaps() -> Vec<Keymap> {
         Keymap::new(
             Input::new(KeyCode::Char('['), KeyModifiers::CONTROL),
             UICommand::FinishEditEntryContent,
+        ),
+    ]
+}
+
+pub fn get_multi_select_keymaps() -> Vec<Keymap> {
+    vec![
+        Keymap::new(
+            Input::new(KeyCode::Esc, KeyModifiers::NONE),
+            UICommand::LeaveMultiSelectMode,
+        ),
+        Keymap::new(
+            Input::new(KeyCode::Char('c'), KeyModifiers::CONTROL),
+            UICommand::LeaveMultiSelectMode,
+        ),
+        Keymap::new(
+            Input::new(KeyCode::Char('['), KeyModifiers::CONTROL),
+            UICommand::LeaveMultiSelectMode,
+        ),
+        Keymap::new(
+            Input::new(KeyCode::Char(' '), KeyModifiers::NONE),
+            UICommand::MulSelToggleSelected,
+        ),
+        Keymap::new(
+            Input::new(KeyCode::Enter, KeyModifiers::NONE),
+            UICommand::MulSelToggleSelected,
+        ),
+        Keymap::new(
+            Input::new(KeyCode::Char('m'), KeyModifiers::CONTROL),
+            UICommand::MulSelToggleSelected,
+        ),
+        Keymap::new(
+            Input::new(KeyCode::Char('a'), KeyModifiers::NONE),
+            UICommand::MulSelSelectAll,
+        ),
+        Keymap::new(
+            Input::new(KeyCode::Char('x'), KeyModifiers::NONE),
+            UICommand::MulSelSelectNone,
+        ),
+        Keymap::new(
+            Input::new(KeyCode::Char('i'), KeyModifiers::NONE),
+            UICommand::MulSelInverSelection,
         ),
     ]
 }

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -276,6 +276,10 @@ pub fn get_multi_select_keymaps() -> Vec<Keymap> {
             UICommand::MulSelInverSelection,
         ),
         Keymap::new(
+            Input::new(KeyCode::Char('d'), KeyModifiers::NONE),
+            UICommand::MulSelDeleteEntries,
+        ),
+        Keymap::new(
             Input::new(KeyCode::Char('?'), KeyModifiers::NONE),
             UICommand::ShowHelp,
         ),

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -214,6 +214,14 @@ pub(crate) fn get_editor_mode_keymaps() -> Vec<Keymap> {
 pub fn get_multi_select_keymaps() -> Vec<Keymap> {
     vec![
         Keymap::new(
+            Input::new(KeyCode::Char('q'), KeyModifiers::NONE),
+            UICommand::LeaveMultiSelectMode,
+        ),
+        Keymap::new(
+            Input::new(KeyCode::Char('v'), KeyModifiers::NONE),
+            UICommand::LeaveMultiSelectMode,
+        ),
+        Keymap::new(
             Input::new(KeyCode::Esc, KeyModifiers::NONE),
             UICommand::LeaveMultiSelectMode,
         ),
@@ -224,6 +232,22 @@ pub fn get_multi_select_keymaps() -> Vec<Keymap> {
         Keymap::new(
             Input::new(KeyCode::Char('['), KeyModifiers::CONTROL),
             UICommand::LeaveMultiSelectMode,
+        ),
+        Keymap::new(
+            Input::new(KeyCode::Up, KeyModifiers::NONE),
+            UICommand::SelectedPrevEntry,
+        ),
+        Keymap::new(
+            Input::new(KeyCode::Char('k'), KeyModifiers::NONE),
+            UICommand::SelectedPrevEntry,
+        ),
+        Keymap::new(
+            Input::new(KeyCode::Down, KeyModifiers::NONE),
+            UICommand::SelectedNextEntry,
+        ),
+        Keymap::new(
+            Input::new(KeyCode::Char('j'), KeyModifiers::NONE),
+            UICommand::SelectedNextEntry,
         ),
         Keymap::new(
             Input::new(KeyCode::Char(' '), KeyModifiers::NONE),
@@ -248,6 +272,10 @@ pub fn get_multi_select_keymaps() -> Vec<Keymap> {
         Keymap::new(
             Input::new(KeyCode::Char('i'), KeyModifiers::NONE),
             UICommand::MulSelInverSelection,
+        ),
+        Keymap::new(
+            Input::new(KeyCode::Char('?'), KeyModifiers::NONE),
+            UICommand::ShowHelp,
         ),
     ]
 }

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -47,7 +47,13 @@ impl Display for Input {
             KeyCode::Delete => "Delete",
             KeyCode::Insert => "Isnert",
             KeyCode::F(_) => "F",
-            KeyCode::Char(char) => char.encode_utf8(&mut char_convert_tmp),
+            KeyCode::Char(char) => {
+                if char.is_whitespace() {
+                    "<Space>"
+                } else {
+                    char.encode_utf8(&mut char_convert_tmp)
+                }
+            }
             KeyCode::Null => "Null",
             KeyCode::Esc => "Esc",
             _ => panic!("{:?} is not implemented", self.key_code),

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -230,10 +230,6 @@ pub fn get_multi_select_keymaps() -> Vec<Keymap> {
             UICommand::LeaveMultiSelectMode,
         ),
         Keymap::new(
-            Input::new(KeyCode::Char('['), KeyModifiers::CONTROL),
-            UICommand::LeaveMultiSelectMode,
-        ),
-        Keymap::new(
             Input::new(KeyCode::Up, KeyModifiers::NONE),
             UICommand::SelectedPrevEntry,
         ),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{collections::HashSet, path::PathBuf};
 
 use backend::{DataProvider, Entry, EntryDraft};
 
@@ -23,6 +23,7 @@ where
     pub data_provide: D,
     pub entries: Vec<Entry>,
     pub current_entry_id: Option<u32>,
+    pub selected_entries: HashSet<u32>,
     pub settings: Settings,
     pub redraw_after_restore: bool,
 }
@@ -33,10 +34,12 @@ where
 {
     pub fn new(data_provide: D, settings: Settings) -> Self {
         let entries = Vec::new();
+        let selected_entries = HashSet::new();
         Self {
             data_provide,
             entries,
             current_entry_id: None,
+            selected_entries,
             settings,
             redraw_after_restore: false,
         }

--- a/src/app/ui/commands/editor_cmd.rs
+++ b/src/app/ui/commands/editor_cmd.rs
@@ -45,12 +45,20 @@ pub fn continue_discard_content<D: DataProvider>(
     msg_box_result: MsgBoxResult,
 ) -> CmdResult {
     match msg_box_result {
-        MsgBoxResult::Yes => ui_components
-            .editor
-            .set_current_entry(app.current_entry_id, app),
+        MsgBoxResult::Yes => discard_current_content(ui_components, app),
         MsgBoxResult::No => {}
         _ => unreachable!("{:?} isn't implemented for discard content", msg_box_result),
     }
 
     Ok(HandleInputReturnType::Handled)
+}
+
+#[inline]
+pub fn discard_current_content<D: DataProvider>(
+    ui_components: &mut UIComponents,
+    app: &mut App<D>,
+) {
+    ui_components
+        .editor
+        .set_current_entry(app.current_entry_id, app);
 }

--- a/src/app/ui/commands/entries_list_cmd.rs
+++ b/src/app/ui/commands/entries_list_cmd.rs
@@ -6,7 +6,10 @@ use backend::DataProvider;
 
 use scopeguard::defer;
 
-use super::{editor_cmd::exec_save_entry_content, CmdResult};
+use super::{
+    editor_cmd::{discard_current_content, exec_save_entry_content},
+    CmdResult,
+};
 
 pub fn exec_select_prev_entry<D: DataProvider>(
     ui_components: &mut UIComponents,
@@ -225,7 +228,10 @@ pub async fn continue_export_entry_content<'a, D: DataProvider>(
             exec_save_entry_content(ui_components, app).await?;
             export_entry_content(ui_components, app);
         }
-        MsgBoxResult::No => export_entry_content(ui_components, app),
+        MsgBoxResult::No => {
+            discard_current_content(ui_components, app);
+            export_entry_content(ui_components, app);
+        }
     }
 
     Ok(HandleInputReturnType::Handled)

--- a/src/app/ui/commands/global_cmd.rs
+++ b/src/app/ui/commands/global_cmd.rs
@@ -32,9 +32,13 @@ pub async fn continue_quit<'a, D: DataProvider>(
 }
 
 pub fn exec_show_help(ui_components: &mut UIComponents) -> CmdResult {
-    let start_tab = match ui_components.active_control {
-        ControlType::EntriesList => KeybindingsTabs::Global,
-        ControlType::EntryContentTxt => KeybindingsTabs::Editor,
+    let start_tab = match (
+        ui_components.active_control,
+        ui_components.entries_list.multi_select_mode,
+    ) {
+        (ControlType::EntriesList, false) => KeybindingsTabs::Global,
+        (ControlType::EntriesList, true) => KeybindingsTabs::MultiSelect,
+        (ControlType::EntryContentTxt, _) => KeybindingsTabs::Editor,
     };
 
     ui_components

--- a/src/app/ui/commands/mod.rs
+++ b/src/app/ui/commands/mod.rs
@@ -1,6 +1,5 @@
-use std::fmt::Debug;
-
 use backend::DataProvider;
+use std::fmt::Debug;
 
 use multi_select_cmd::*;
 
@@ -162,10 +161,10 @@ impl UICommand {
             }
             UICommand::EnterMultiSelectMode => exec_enter_select_mode(ui_components),
             UICommand::LeaveMultiSelectMode => exec_leave_select_mode(ui_components),
-            UICommand::MulSelToggleSelected => exec_toggle_selected(ui_components, app),
-            UICommand::MulSelSelectAll => exec_select_all(ui_components, app),
-            UICommand::MulSelSelectNone => exec_select_none(ui_components, app),
-            UICommand::MulSelInverSelection => exec_invert_selection(ui_components, app),
+            UICommand::MulSelToggleSelected => exec_toggle_selected(app),
+            UICommand::MulSelSelectAll => exec_select_all(app),
+            UICommand::MulSelSelectNone => exec_select_none(app),
+            UICommand::MulSelInverSelection => exec_invert_selection(app),
         }
     }
 

--- a/src/app/ui/commands/mod.rs
+++ b/src/app/ui/commands/mod.rs
@@ -2,6 +2,8 @@ use std::fmt::Debug;
 
 use backend::DataProvider;
 
+use multi_select_cmd::*;
+
 use super::{App, HandleInputReturnType, MsgBoxResult, UIComponents};
 
 use editor_cmd::*;
@@ -11,6 +13,7 @@ use global_cmd::*;
 mod editor_cmd;
 mod entries_list_cmd;
 mod global_cmd;
+mod multi_select_cmd;
 
 type CmdResult = anyhow::Result<HandleInputReturnType>;
 
@@ -32,6 +35,12 @@ pub enum UICommand {
     ReloadAll,
     ExportEntryContent,
     EditInExternalEditor,
+    EnterMultiSelectMode,
+    LeaveMultiSelectMode,
+    MulSelToggleSelected,
+    MulSelSelectAll,
+    MulSelSelectNone,
+    MulSelInverSelection,
 }
 
 #[derive(Debug, Clone)]
@@ -100,6 +109,30 @@ impl UICommand {
                 "Edit in external editor",
                 "Edit current journal content in external editor (The editor can be set in configurations file or via the environment variables VISUAL, EDITOR)",
             ),
+            UICommand::EnterMultiSelectMode => CommandInfo::new(
+                "Enter journals multi selection mode",
+                "Enter multi selection mode for journals to work with multi journals at once",
+            ),
+            UICommand::LeaveMultiSelectMode => CommandInfo::new(
+                "Leave journals multi selection mode",
+                "Leave multi selection mode for journals and return to normal mode",
+            ),
+            UICommand::MulSelToggleSelected => CommandInfo::new(
+                "Toggle selected",
+                "Toggle if the current journal is selected in multi selection mode",
+            ),
+            UICommand::MulSelSelectAll => CommandInfo::new(
+                "Select all journals",
+                "Select all journals in multi selection mode",
+            ),
+            UICommand::MulSelSelectNone => CommandInfo::new(
+                "Clear selection",
+                "Clear journals selection in multi selection mode",
+            ),
+            UICommand::MulSelInverSelection => CommandInfo::new(
+                "Invert selection",
+                "Invert journals selection in multi selection mode",
+            ),
         }
     }
 
@@ -127,6 +160,12 @@ impl UICommand {
             UICommand::EditInExternalEditor => {
                 exec_edit_in_external_editor(ui_components, app).await
             }
+            UICommand::EnterMultiSelectMode => exec_enter_select_mode(ui_components),
+            UICommand::LeaveMultiSelectMode => exec_leave_select_mode(ui_components),
+            UICommand::MulSelToggleSelected => exec_toggle_selected(ui_components, app),
+            UICommand::MulSelSelectAll => exec_select_all(ui_components, app),
+            UICommand::MulSelSelectNone => exec_select_none(ui_components, app),
+            UICommand::MulSelInverSelection => exec_invert_selection(ui_components, app),
         }
     }
 
@@ -168,6 +207,14 @@ impl UICommand {
             UICommand::EditInExternalEditor => {
                 continue_edit_in_external_editor(ui_components, app, msg_box_result).await
             }
+            UICommand::EnterMultiSelectMode => {
+                continue_enter_select_mode(ui_components, app, msg_box_result).await
+            }
+            UICommand::LeaveMultiSelectMode => not_implemented(),
+            UICommand::MulSelToggleSelected => not_implemented(),
+            UICommand::MulSelSelectAll => not_implemented(),
+            UICommand::MulSelSelectNone => not_implemented(),
+            UICommand::MulSelInverSelection => not_implemented(),
         }
     }
 }

--- a/src/app/ui/commands/mod.rs
+++ b/src/app/ui/commands/mod.rs
@@ -160,7 +160,7 @@ impl UICommand {
                 exec_edit_in_external_editor(ui_components, app).await
             }
             UICommand::EnterMultiSelectMode => exec_enter_select_mode(ui_components),
-            UICommand::LeaveMultiSelectMode => exec_leave_select_mode(ui_components),
+            UICommand::LeaveMultiSelectMode => exec_leave_select_mode(ui_components, app),
             UICommand::MulSelToggleSelected => exec_toggle_selected(app),
             UICommand::MulSelSelectAll => exec_select_all(app),
             UICommand::MulSelSelectNone => exec_select_none(app),

--- a/src/app/ui/commands/mod.rs
+++ b/src/app/ui/commands/mod.rs
@@ -40,6 +40,7 @@ pub enum UICommand {
     MulSelSelectAll,
     MulSelSelectNone,
     MulSelInverSelection,
+    MulSelDeleteEntries,
 }
 
 #[derive(Debug, Clone)]
@@ -132,6 +133,10 @@ impl UICommand {
                 "Invert selection",
                 "Invert journals selection in multi selection mode",
             ),
+            UICommand::MulSelDeleteEntries => CommandInfo::new(
+                "Delete selection",
+                "Delete selected journals in multi selection mode",
+            ),
         }
     }
 
@@ -165,6 +170,7 @@ impl UICommand {
             UICommand::MulSelSelectAll => exec_select_all(app),
             UICommand::MulSelSelectNone => exec_select_none(app),
             UICommand::MulSelInverSelection => exec_invert_selection(app),
+            UICommand::MulSelDeleteEntries => exec_delete_selected_entries(ui_components, app),
         }
     }
 
@@ -189,7 +195,9 @@ impl UICommand {
             UICommand::CreateEntry => {
                 continue_create_entry(ui_components, app, msg_box_result).await
             }
-            UICommand::EditCurrentEntry => not_implemented(),
+            UICommand::EditCurrentEntry => {
+                continue_edit_current_entry(ui_components, app, msg_box_result).await
+            }
             UICommand::DeleteCurrentEntry => {
                 continue_delete_current_entry(ui_components, app, msg_box_result).await
             }
@@ -214,6 +222,9 @@ impl UICommand {
             UICommand::MulSelSelectAll => not_implemented(),
             UICommand::MulSelSelectNone => not_implemented(),
             UICommand::MulSelInverSelection => not_implemented(),
+            UICommand::MulSelDeleteEntries => {
+                continue_delete_selected_entries(ui_components, app, msg_box_result).await
+            }
         }
     }
 }

--- a/src/app/ui/commands/multi_select_cmd.rs
+++ b/src/app/ui/commands/multi_select_cmd.rs
@@ -67,14 +67,14 @@ pub fn exec_leave_select_mode<D: DataProvider>(
 
 pub fn exec_toggle_selected<D: DataProvider>(app: &mut App<D>) -> CmdResult {
     if let Some(id) = app.get_current_entry().map(|entry| entry.id) {
-        toggle_entrie_selection(id, app);
+        toggle_entry_selection(id, app);
     }
 
     Ok(HandleInputReturnType::Handled)
 }
 
 #[inline]
-fn toggle_entrie_selection<D: DataProvider>(entry_id: u32, app: &mut App<D>) {
+fn toggle_entry_selection<D: DataProvider>(entry_id: u32, app: &mut App<D>) {
     if !app.selected_entries.insert(entry_id) {
         // entry was selected, then remove it
         app.selected_entries.remove(&entry_id);
@@ -99,7 +99,7 @@ pub fn exec_invert_selection<D: DataProvider>(app: &mut App<D>) -> CmdResult {
     let entries_ids: Vec<u32> = app.entries.iter().map(|entry| entry.id).collect();
 
     entries_ids.into_iter().for_each(|id| {
-        toggle_entrie_selection(id, app);
+        toggle_entry_selection(id, app);
     });
 
     Ok(HandleInputReturnType::Handled)

--- a/src/app/ui/commands/multi_select_cmd.rs
+++ b/src/app/ui/commands/multi_select_cmd.rs
@@ -2,7 +2,10 @@ use backend::DataProvider;
 
 use crate::app::{ui::MsgBoxResult, App, HandleInputReturnType, UIComponents};
 
-use super::{editor_cmd::exec_save_entry_content, CmdResult, UICommand};
+use super::{
+    editor_cmd::{discard_current_content, exec_save_entry_content},
+    CmdResult, UICommand,
+};
 
 pub fn exec_enter_select_mode(ui_components: &mut UIComponents) -> CmdResult {
     if ui_components.entries_list.multi_select_mode {
@@ -34,7 +37,10 @@ pub async fn continue_enter_select_mode<'a, D: DataProvider>(
             exec_save_entry_content(ui_components, app).await?;
             enter_select_mode(ui_components);
         }
-        MsgBoxResult::No => enter_select_mode(ui_components),
+        MsgBoxResult::No => {
+            discard_current_content(ui_components, app);
+            enter_select_mode(ui_components);
+        }
     }
 
     Ok(HandleInputReturnType::Handled)

--- a/src/app/ui/commands/multi_select_cmd.rs
+++ b/src/app/ui/commands/multi_select_cmd.rs
@@ -1,0 +1,78 @@
+use backend::DataProvider;
+
+use crate::app::{ui::MsgBoxResult, App, HandleInputReturnType, UIComponents};
+
+use super::{editor_cmd::exec_save_entry_content, CmdResult, UICommand};
+
+pub fn exec_enter_select_mode(ui_components: &mut UIComponents) -> CmdResult {
+    if ui_components.entries_list.multi_select_mode {
+        return Ok(HandleInputReturnType::Handled);
+    }
+
+    if ui_components.has_unsaved() {
+        ui_components.show_unsaved_msg_box(Some(UICommand::EnterMultiSelectMode));
+    } else {
+        enter_select_mode(ui_components);
+    }
+
+    Ok(HandleInputReturnType::Handled)
+}
+
+#[inline]
+fn enter_select_mode(ui_components: &mut UIComponents) {
+    ui_components.entries_list.multi_select_mode = true;
+}
+
+pub async fn continue_enter_select_mode<'a, D: DataProvider>(
+    ui_components: &mut UIComponents<'a>,
+    app: &mut App<D>,
+    msg_box_result: MsgBoxResult,
+) -> CmdResult {
+    match msg_box_result {
+        MsgBoxResult::Ok | MsgBoxResult::Cancel => {}
+        MsgBoxResult::Yes => {
+            exec_save_entry_content(ui_components, app).await?;
+            enter_select_mode(ui_components);
+        }
+        MsgBoxResult::No => enter_select_mode(ui_components),
+    }
+
+    Ok(HandleInputReturnType::Handled)
+}
+
+pub fn exec_leave_select_mode(ui_components: &mut UIComponents) -> CmdResult {
+    debug_assert!(ui_components.entries_list.multi_select_mode);
+    debug_assert!(!ui_components.has_unsaved());
+
+    ui_components.entries_list.multi_select_mode = false;
+
+    Ok(HandleInputReturnType::Handled)
+}
+
+pub fn exec_toggle_selected<D: DataProvider>(
+    ui_components: &mut UIComponents,
+    app: &mut App<D>,
+) -> CmdResult {
+    todo!()
+}
+
+pub fn exec_select_all<D: DataProvider>(
+    ui_components: &mut UIComponents,
+    app: &mut App<D>,
+) -> CmdResult {
+    todo!()
+}
+
+pub fn exec_select_none<D: DataProvider>(
+    ui_components: &mut UIComponents,
+    app: &mut App<D>,
+) -> CmdResult {
+    todo!()
+}
+
+pub fn exec_invert_selection<D: DataProvider>(
+    ui_components: &mut UIComponents,
+    app: &mut App<D>,
+) -> CmdResult {
+    todo!()
+}

--- a/src/app/ui/commands/multi_select_cmd.rs
+++ b/src/app/ui/commands/multi_select_cmd.rs
@@ -49,30 +49,42 @@ pub fn exec_leave_select_mode(ui_components: &mut UIComponents) -> CmdResult {
     Ok(HandleInputReturnType::Handled)
 }
 
-pub fn exec_toggle_selected<D: DataProvider>(
-    ui_components: &mut UIComponents,
-    app: &mut App<D>,
-) -> CmdResult {
-    todo!()
+pub fn exec_toggle_selected<D: DataProvider>(app: &mut App<D>) -> CmdResult {
+    if let Some(id) = app.get_current_entry().map(|entry| entry.id) {
+        toggle_entrie_selection(id, app);
+    }
+
+    Ok(HandleInputReturnType::Handled)
 }
 
-pub fn exec_select_all<D: DataProvider>(
-    ui_components: &mut UIComponents,
-    app: &mut App<D>,
-) -> CmdResult {
-    todo!()
+#[inline]
+fn toggle_entrie_selection<D: DataProvider>(entry_id: u32, app: &mut App<D>) {
+    if !app.selected_entries.insert(entry_id) {
+        // entry was selected, then remove it
+        app.selected_entries.remove(&entry_id);
+    }
 }
 
-pub fn exec_select_none<D: DataProvider>(
-    ui_components: &mut UIComponents,
-    app: &mut App<D>,
-) -> CmdResult {
-    todo!()
+pub fn exec_select_all<D: DataProvider>(app: &mut App<D>) -> CmdResult {
+    app.entries.iter().map(|entry| entry.id).for_each(|id| {
+        app.selected_entries.insert(id);
+    });
+
+    Ok(HandleInputReturnType::Handled)
 }
 
-pub fn exec_invert_selection<D: DataProvider>(
-    ui_components: &mut UIComponents,
-    app: &mut App<D>,
-) -> CmdResult {
-    todo!()
+pub fn exec_select_none<D: DataProvider>(app: &mut App<D>) -> CmdResult {
+    app.selected_entries.clear();
+
+    Ok(HandleInputReturnType::Handled)
+}
+
+pub fn exec_invert_selection<D: DataProvider>(app: &mut App<D>) -> CmdResult {
+    let entries_ids: Vec<u32> = app.entries.iter().map(|entry| entry.id).collect();
+
+    entries_ids.into_iter().for_each(|id| {
+        toggle_entrie_selection(id, app);
+    });
+
+    Ok(HandleInputReturnType::Handled)
 }

--- a/src/app/ui/commands/multi_select_cmd.rs
+++ b/src/app/ui/commands/multi_select_cmd.rs
@@ -40,10 +40,14 @@ pub async fn continue_enter_select_mode<'a, D: DataProvider>(
     Ok(HandleInputReturnType::Handled)
 }
 
-pub fn exec_leave_select_mode(ui_components: &mut UIComponents) -> CmdResult {
+pub fn exec_leave_select_mode<D: DataProvider>(
+    ui_components: &mut UIComponents,
+    app: &mut App<D>,
+) -> CmdResult {
     debug_assert!(ui_components.entries_list.multi_select_mode);
     debug_assert!(!ui_components.has_unsaved());
 
+    exec_select_none(app)?;
     ui_components.entries_list.multi_select_mode = false;
 
     Ok(HandleInputReturnType::Handled)

--- a/src/app/ui/entries_list/mod.rs
+++ b/src/app/ui/entries_list/mod.rs
@@ -119,7 +119,11 @@ impl<'a> EntriesList {
             .map(|keymap| format!("'{}'", keymap.key))
             .collect();
 
-        let place_holder_text = format!("\n Use {} to create new entry ", keys_text.join(","));
+        let place_holder_text = if self.multi_select_mode {
+            String::from("\nNo entries to select")
+        } else {
+            format!("\n Use {} to create new entry ", keys_text.join(","))
+        };
 
         let place_holder = Paragraph::new(place_holder_text)
             .wrap(Wrap { trim: false })

--- a/src/app/ui/entries_list/mod.rs
+++ b/src/app/ui/entries_list/mod.rs
@@ -7,9 +7,10 @@ use tui::text::{Span, Spans};
 use tui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap};
 use tui::Frame;
 
-use backend::Entry;
+use backend::DataProvider;
 
 use crate::app::keymap::Keymap;
+use crate::app::App;
 
 use super::INACTIVE_CONTROL_COLOR;
 use super::{UICommand, ACTIVE_CONTROL_COLOR};
@@ -20,6 +21,7 @@ const LIST_INNER_MARGINE: usize = 5;
 pub struct EntriesList {
     pub state: ListState,
     is_active: bool,
+    pub multi_select_mode: bool,
 }
 
 impl<'a> EntriesList {
@@ -27,17 +29,24 @@ impl<'a> EntriesList {
         Self {
             state: ListState::default(),
             is_active: false,
+            multi_select_mode: false,
         }
     }
 
-    fn render_list<B: Backend>(&mut self, frame: &mut Frame<B>, entries: &'a [Entry], area: Rect) {
+    fn render_list<B: Backend, D: DataProvider>(
+        &mut self,
+        frame: &mut Frame<B>,
+        app: &App<D>,
+        area: Rect,
+    ) {
         let (foreground_color, highlight_bg) = if self.is_active {
             (ACTIVE_CONTROL_COLOR, Color::LightGreen)
         } else {
             (INACTIVE_CONTROL_COLOR, Color::LightBlue)
         };
 
-        let items: Vec<ListItem> = entries
+        let items: Vec<ListItem> = app
+            .entries
             .iter()
             .map(|entry| {
                 // Text wrapping
@@ -122,17 +131,17 @@ impl<'a> EntriesList {
             })
     }
 
-    pub fn render_widget<B: Backend>(
+    pub fn render_widget<B: Backend, D: DataProvider>(
         &mut self,
         frame: &mut Frame<B>,
         area: Rect,
-        entries: &'a [Entry],
+        app: &App<D>,
         list_keymaps: &[Keymap],
     ) {
-        if entries.is_empty() {
+        if app.entries.is_empty() {
             self.render_place_holder(frame, area, list_keymaps);
         } else {
-            self.render_list(frame, entries, area);
+            self.render_list(frame, app, area);
         }
     }
 

--- a/src/app/ui/footer.rs
+++ b/src/app/ui/footer.rs
@@ -12,43 +12,14 @@ use crate::app::keymap::Keymap;
 use super::{UICommand, UIComponents};
 
 pub fn render_footer<B: Backend>(frame: &mut Frame<B>, area: Rect, ui_components: &UIComponents) {
-    let spans = if ui_components.editor.is_insert_mode() {
-        let exit_editor_mode_keymap: Vec<_> = ui_components
-            .editor_keymaps
-            .iter()
-            .filter(|keymap| keymap.command == UICommand::FinishEditEntryContent)
-            .collect();
-
-        Spans::from(vec![
-            get_keymap_spans(exit_editor_mode_keymap),
-            Span::raw(" | Edit using Emacs motions"),
-        ])
-    } else {
-        let close_keymap: Vec<_> = ui_components
-            .global_keymaps
-            .iter()
-            .filter(|keymap| keymap.command == UICommand::Quit)
-            .collect();
-
-        let help_keymap: Vec<_> = ui_components
-            .global_keymaps
-            .iter()
-            .filter(|keymap| keymap.command == UICommand::ShowHelp)
-            .collect();
-
-        let enter_editor_keymap: Vec<_> = ui_components
-            .global_keymaps
-            .iter()
-            .filter(|keymap| keymap.command == UICommand::StartEditEntryContent)
-            .collect();
-
-        Spans::from(vec![
-            get_keymap_spans(close_keymap),
-            Span::raw(" | "),
-            get_keymap_spans(enter_editor_keymap),
-            Span::raw(" | "),
-            get_keymap_spans(help_keymap),
-        ])
+    let (edior_mode, multi_select_mode) = (
+        ui_components.editor.is_insert_mode(),
+        ui_components.entries_list.multi_select_mode,
+    );
+    let spans = match (edior_mode, multi_select_mode) {
+        (true, false) => get_editor_mode_spans(ui_components),
+        (false, true) => get_multi_select_spans(ui_components),
+        _ => get_standard_spans(ui_components),
     };
     let footer = Paragraph::new(spans).alignment(Alignment::Left).block(
         Block::default()
@@ -57,6 +28,67 @@ pub fn render_footer<B: Backend>(frame: &mut Frame<B>, area: Rect, ui_components
     );
 
     frame.render_widget(footer, area);
+}
+
+fn get_editor_mode_spans<'a>(ui_components: &'a UIComponents) -> Spans<'a> {
+    let exit_editor_mode_keymap: Vec<_> = ui_components
+        .editor_keymaps
+        .iter()
+        .filter(|keymap| keymap.command == UICommand::FinishEditEntryContent)
+        .collect();
+
+    Spans::from(vec![
+        get_keymap_spans(exit_editor_mode_keymap),
+        Span::raw(" | Edit using Emacs motions"),
+    ])
+}
+
+fn get_standard_spans<'a>(ui_components: &'a UIComponents) -> Spans<'a> {
+    let close_keymap: Vec<_> = ui_components
+        .global_keymaps
+        .iter()
+        .filter(|keymap| keymap.command == UICommand::Quit)
+        .collect();
+
+    let help_keymap: Vec<_> = ui_components
+        .global_keymaps
+        .iter()
+        .filter(|keymap| keymap.command == UICommand::ShowHelp)
+        .collect();
+
+    let enter_editor_keymap: Vec<_> = ui_components
+        .global_keymaps
+        .iter()
+        .filter(|keymap| keymap.command == UICommand::StartEditEntryContent)
+        .collect();
+
+    Spans::from(vec![
+        get_keymap_spans(close_keymap),
+        Span::raw(" | "),
+        get_keymap_spans(enter_editor_keymap),
+        Span::raw(" | "),
+        get_keymap_spans(help_keymap),
+    ])
+}
+
+fn get_multi_select_spans<'a>(ui_components: &'a UIComponents) -> Spans<'a> {
+    let leave_keymap: Vec<_> = ui_components
+        .multi_select_keymaps
+        .iter()
+        .filter(|keymap| keymap.command == UICommand::LeaveMultiSelectMode)
+        .collect();
+
+    let help_keymap: Vec<_> = ui_components
+        .multi_select_keymaps
+        .iter()
+        .filter(|keymap| keymap.command == UICommand::ShowHelp)
+        .collect();
+
+    Spans::from(vec![
+        get_keymap_spans(leave_keymap),
+        Span::raw(" | "),
+        get_keymap_spans(help_keymap),
+    ])
 }
 
 fn get_keymap_spans(keymaps: Vec<&Keymap>) -> Span {

--- a/src/app/ui/help_popup/multi_select_bindings.rs
+++ b/src/app/ui/help_popup/multi_select_bindings.rs
@@ -1,0 +1,48 @@
+use std::collections::BTreeMap;
+
+use tui::widgets::TableState;
+
+use crate::app::{
+    keymap::{get_multi_select_keymaps, Input},
+    ui::UICommand,
+};
+
+use super::keybindings_table::KeybindingsTable;
+
+#[derive(Debug)]
+pub struct MultiSelectBindings {
+    state: TableState,
+    bingings_map: BTreeMap<UICommand, Vec<Input>>,
+}
+
+impl MultiSelectBindings {
+    pub fn new() -> Self {
+        let state = TableState::default();
+        let mut bingings_map: BTreeMap<UICommand, Vec<Input>> = BTreeMap::new();
+
+        get_multi_select_keymaps().into_iter().for_each(|keymap| {
+            bingings_map
+                .entry(keymap.command)
+                .and_modify(|keys| keys.push(keymap.key))
+                .or_insert(vec![keymap.key]);
+        });
+        Self {
+            state,
+            bingings_map,
+        }
+    }
+}
+
+impl KeybindingsTable for MultiSelectBindings {
+    fn get_state_mut(&mut self) -> &mut TableState {
+        &mut self.state
+    }
+
+    fn get_bindings_map(&self) -> &BTreeMap<UICommand, Vec<Input>> {
+        &self.bingings_map
+    }
+
+    fn get_title(&self) -> &str {
+        "Multi-Select Mode Keybindings"
+    }
+}

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -12,7 +12,8 @@ use self::{
 
 use super::{
     keymap::{
-        get_editor_mode_keymaps, get_entries_list_keymaps, get_global_keymaps, Input, Keymap,
+        get_editor_mode_keymaps, get_entries_list_keymaps, get_global_keymaps,
+        get_multi_select_keymaps, Input, Keymap,
     },
     runner::HandleInputReturnType,
     App,
@@ -61,6 +62,7 @@ pub struct UIComponents<'a> {
     global_keymaps: Vec<Keymap>,
     entries_list_keymaps: Vec<Keymap>,
     editor_keymaps: Vec<Keymap>,
+    multi_select_keymaps: Vec<Keymap>,
     entries_list: EntriesList,
     editor: Editor<'a>,
     popup_stack: Vec<Popup<'a>>,
@@ -73,6 +75,7 @@ impl<'a, 'b> UIComponents<'a> {
         let global_keymaps = get_global_keymaps();
         let entries_list_keymaps = get_entries_list_keymaps();
         let editor_keymaps = get_editor_mode_keymaps();
+        let multi_select_keymaps = get_multi_select_keymaps();
         let mut entries_list = EntriesList::new();
         let editor = Editor::new();
 
@@ -83,6 +86,7 @@ impl<'a, 'b> UIComponents<'a> {
             global_keymaps,
             entries_list_keymaps,
             editor_keymaps,
+            multi_select_keymaps,
             entries_list,
             editor,
             popup_stack: Vec::new(),
@@ -157,6 +161,13 @@ impl<'a, 'b> UIComponents<'a> {
                 return key.command.clone().execute(self, app).await;
             }
             return self.editor.handle_input(input, app);
+        }
+
+        if self.entries_list.multi_select_mode {
+            if let Some(key) = self.multi_select_keymaps.iter().find(|c| &c.key == input) {
+                return key.command.to_owned().execute(self, app).await;
+            }
+            return Ok(HandleInputReturnType::Handled);
         }
 
         if let Some(cmd) = self

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -122,12 +122,8 @@ impl<'a, 'b> UIComponents<'a> {
             .constraints([Constraint::Percentage(30), Constraint::Percentage(70)].as_ref())
             .split(chunks[0]);
 
-        self.entries_list.render_widget(
-            f,
-            entries_chunks[0],
-            &app.entries,
-            &self.entries_list_keymaps,
-        );
+        self.entries_list
+            .render_widget(f, entries_chunks[0], app, &self.entries_list_keymaps);
         self.editor.render_widget(f, entries_chunks[1]);
 
         self.render_popup(f);


### PR DESCRIPTION
This PR closes #7 

The following was added:
- A new multi-select mode (with `v` keybinding) for journals with the following functions:
1. Toggle selection for the current journal with `space` `enter` `<Ctrl-m>`
2. Select all journals with `a`
3. Select none with `x`
4. Invert selection with `i`
- A delete function inside the multi-select mode to delete many journals at once `d`
- A new tab in the help popup where the keybindings are explained
- Adjustments on the footer to show the important keybindings when multi-select mode is active
- Fixes for small mistakes regarding discarding the journal after the save prompt