### PR TITLE
Changed:  bump baptiste0928/cargo-install to v2.1.0

### DIFF
--- a/.github/workflows/changelog-assembly.yml
+++ b/.github/workflows/changelog-assembly.yml
@@ -8,15 +8,15 @@ permissions:
   pull-requests: write
 
 jobs:
-  scriv:
-    name: scriv
+  ronlog:
+    name: ronlog
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.2
-
+      - uses: fregante/setup-git-user@v2.0.1
       - run: rustup update
 
-      - uses: baptiste0928/cargo-install@v2.0.0
+      - uses: baptiste0928/cargo-install@v2.1.0
         with:
           crate: aeruginous
 
@@ -30,6 +30,7 @@ jobs:
           assignees: |
             AmmarAbouZor
           branch: documentation/scriv-assemble-changelog
+          branch-suffix: timestamp
           commit-message: '[Aeruginous] Assemble CHANGELOG'
           labels: |
             documentation

--- a/.github/workflows/changelog-assembly.yml
+++ b/.github/workflows/changelog-assembly.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           assignees: |
             AmmarAbouZor
-          branch: documentation/scriv-assemble-changelog
+          branch: documentation/aeruginous-ronlog
           branch-suffix: timestamp
           commit-message: '[Aeruginous] Assemble CHANGELOG'
           labels: |

--- a/.github/workflows/comment-changes.yml
+++ b/.github/workflows/comment-changes.yml
@@ -45,6 +45,7 @@ jobs:
           assignees: |
             AmmarAbouZor
           branch: documentation/aeruginous-comment-changes
+          branch-suffix: timestamp
           commit-message: '[Aeruginous] Create CHANGELOG Fragment'
           labels: |
             documentation

--- a/.github/workflows/comment-changes.yml
+++ b/.github/workflows/comment-changes.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   aeruginous:
     if: |
+      github.repository == 'AmmarAbouZor/tui-journal' &&
       !contains(github.event.head_commit.message, '[Aeruginous]') &&
       !contains(github.event.head_commit.message, 'Chore:') &&
       !contains(github.event.head_commit.message, 'Docs:')

--- a/.github/workflows/comment-changes.yml
+++ b/.github/workflows/comment-changes.yml
@@ -23,9 +23,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: fregante/setup-git-user@v2.0.1
       - run: rustup update
 
-      - uses: baptiste0928/cargo-install@v2.0.0
+      - uses: baptiste0928/cargo-install@v2.1.0
         with:
           crate: aeruginous
 

--- a/changelog.d/20230609_155121_Kevin_Matthes_update-cargo-install.ron
+++ b/changelog.d/20230609_155121_Kevin_Matthes_update-cargo-install.ron
@@ -1,0 +1,12 @@
+(
+  references: {},
+  changes: {
+    "Fixed": [
+      "bugs in fragment creation",
+    ],
+    "Added": [
+      "Multi-selection for journals",
+      "Tabs and scrolling to help popup",
+    ],
+  },
+)


### PR DESCRIPTION
This PR updates the `cargo-install` Action to its latest version.

In order to make sure that affected workflows still work, I tested them and adjusted the necessary points.  I will add a review in the following to explain the changes.