### PR TITLE
Added: Export Import functions for multiple journals

### DIFF
--- a/backend/src/json.rs
+++ b/backend/src/json.rs
@@ -104,19 +104,6 @@ impl DataProvider for JsonDataProvide {
 
         Ok(EntriesDTO::new(entries))
     }
-
-    async fn import_entries(&self, entries_dto: EntriesDTO) -> anyhow::Result<()> {
-        debug_assert_eq!(
-            TRANSFER_DATA_VERSION, entries_dto.version,
-            "Version mismatches check if there is a need to make some conversation"
-        );
-
-        for entry_darft in entries_dto.entries {
-            self.add_entry(entry_darft).await?;
-        }
-
-        Ok(())
-    }
 }
 
 impl JsonDataProvide {

--- a/backend/src/json.rs
+++ b/backend/src/json.rs
@@ -104,6 +104,19 @@ impl DataProvider for JsonDataProvide {
 
         Ok(EntriesDTO::new(entries))
     }
+
+    async fn import_entries(&self, entries_dto: EntriesDTO) -> anyhow::Result<()> {
+        debug_assert_eq!(
+            TRANSFER_DATA_VERSION, entries_dto.version,
+            "Version mismatches check if there is a need to do a converting to the data"
+        );
+
+        for entry_darft in entries_dto.entries {
+            self.add_entry(entry_darft).await?;
+        }
+
+        Ok(())
+    }
 }
 
 impl JsonDataProvide {

--- a/backend/src/json.rs
+++ b/backend/src/json.rs
@@ -92,6 +92,31 @@ impl DataProvider for JsonDataProvide {
             ))
         }
     }
+
+    async fn get_export_object(&self, entries_ids: &[u32]) -> anyhow::Result<EntriesDTO> {
+        let entries: Vec<EntryDraft> = self
+            .load_all_entries()
+            .await?
+            .into_iter()
+            .filter(|entry| entries_ids.contains(&entry.id))
+            .map(EntryDraft::from_entry)
+            .collect();
+
+        Ok(EntriesDTO::new(entries))
+    }
+
+    async fn import_entries(&self, entries_dto: EntriesDTO) -> anyhow::Result<()> {
+        debug_assert_eq!(
+            TRANSFER_DATA_VERSION, entries_dto.version,
+            "Version mismatches check if there is a need to make some conversation"
+        );
+
+        for entry_darft in entries_dto.entries {
+            self.add_entry(entry_darft).await?;
+        }
+
+        Ok(())
+    }
 }
 
 impl JsonDataProvide {

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -2,7 +2,6 @@ use chrono::{DateTime, Utc};
 
 use async_trait::async_trait;
 
-#[cfg(feature = "json")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "sqlite")]

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -35,18 +35,7 @@ pub trait DataProvider {
     async fn remove_entry(&self, entry_id: u32) -> anyhow::Result<()>;
     async fn update_entry(&self, entry: Entry) -> Result<Entry, ModifyEntryError>;
     async fn get_export_object(&self, entries_ids: &[u32]) -> anyhow::Result<EntriesDTO>;
-    async fn import_entries(&self, entries_dto: EntriesDTO) -> anyhow::Result<()> {
-        debug_assert_eq!(
-            TRANSFER_DATA_VERSION, entries_dto.version,
-            "Version mismatches check if there is a need to do a converting to the data"
-        );
-
-        for entry_darft in entries_dto.entries {
-            self.add_entry(entry_darft).await?;
-        }
-
-        Ok(())
-    }
+    async fn import_entries(&self, entries_dto: EntriesDTO) -> anyhow::Result<()>;
 }
 
 #[cfg_attr(feature = "sqlite", derive(FromRow))]

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -35,7 +35,18 @@ pub trait DataProvider {
     async fn remove_entry(&self, entry_id: u32) -> anyhow::Result<()>;
     async fn update_entry(&self, entry: Entry) -> Result<Entry, ModifyEntryError>;
     async fn get_export_object(&self, entries_ids: &[u32]) -> anyhow::Result<EntriesDTO>;
-    async fn import_entries(&self, entries_dto: EntriesDTO) -> anyhow::Result<()>;
+    async fn import_entries(&self, entries_dto: EntriesDTO) -> anyhow::Result<()> {
+        debug_assert_eq!(
+            TRANSFER_DATA_VERSION, entries_dto.version,
+            "Version mismatches check if there is a need to do a converting to the data"
+        );
+
+        for entry_darft in entries_dto.entries {
+            self.add_entry(entry_darft).await?;
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg_attr(feature = "sqlite", derive(FromRow))]

--- a/backend/src/sqlite/mod.rs
+++ b/backend/src/sqlite/mod.rs
@@ -112,4 +112,12 @@ impl DataProvider for SqliteDataProvide {
 
         Ok(entry)
     }
+
+    async fn get_export_object(&self, entries_ids: &[u32]) -> anyhow::Result<EntriesDTO> {
+        todo!()
+    }
+
+    async fn import_entries(&self, entries_dto: EntriesDTO) -> anyhow::Result<()> {
+        todo!()
+    }
 }

--- a/backend/src/sqlite/mod.rs
+++ b/backend/src/sqlite/mod.rs
@@ -139,4 +139,17 @@ impl DataProvider for SqliteDataProvide {
 
         Ok(EntriesDTO::new(entry_drafts))
     }
+
+    async fn import_entries(&self, entries_dto: EntriesDTO) -> anyhow::Result<()> {
+        debug_assert_eq!(
+            TRANSFER_DATA_VERSION, entries_dto.version,
+            "Version mismatches check if there is a need to do a converting to the data"
+        );
+
+        for entry_darft in entries_dto.entries {
+            self.add_entry(entry_darft).await?;
+        }
+
+        Ok(())
+    }
 }

--- a/backend/src/sqlite/mod.rs
+++ b/backend/src/sqlite/mod.rs
@@ -120,18 +120,20 @@ impl DataProvider for SqliteDataProvide {
             .collect::<Vec<String>>()
             .join(", ");
 
-        let entries: Vec<Entry> = sqlx::query_as(
+        let sql = format!(
             r"SELECT * FROM entries
-        WHERE id IN ($1)
+        WHERE id IN ({})
         ORDER BY date DESC",
-        )
-        .bind(&ids_text)
-        .fetch_all(&self.pool)
-        .await
-        .map_err(|err| {
-            log::error!("Loading entries failed. Error Info {err}");
-            anyhow!(err)
-        })?;
+            ids_text
+        );
+
+        let entries: Vec<Entry> = sqlx::query_as(sql.as_str())
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|err| {
+                log::error!("Loading entries failed. Error Info {err}");
+                anyhow!(err)
+            })?;
 
         let entry_drafts = entries.into_iter().map(EntryDraft::from_entry).collect();
 

--- a/backend/tests/json/mod.rs
+++ b/backend/tests/json/mod.rs
@@ -89,3 +89,28 @@ async fn update_entry() {
     assert_eq!(entries[0].content, String::from("Updated Content"));
     assert_eq!(entries[1].title, String::from("Updated Title"));
 }
+
+#[tokio::test]
+async fn text_export_import() {
+    let temp_file_source = TempFile::new("json_export_source");
+    let provider_source = create_provide_with_two_entries(temp_file_source.file_path.clone()).await;
+
+    let created_ids = [0, 1];
+
+    let dto_source = provider_source
+        .get_export_object(&created_ids)
+        .await
+        .unwrap();
+
+    let temp_file_dist = TempFile::new("json_export_dist");
+    let provider_dist = JsonDataProvide::new(temp_file_dist.file_path.clone());
+
+    provider_dist
+        .import_entries(dto_source.clone())
+        .await
+        .unwrap();
+
+    let dto_dist = provider_dist.get_export_object(&created_ids).await.unwrap();
+
+    assert_eq!(dto_source, dto_dist);
+}

--- a/backend/tests/json/mod.rs
+++ b/backend/tests/json/mod.rs
@@ -102,6 +102,8 @@ async fn text_export_import() {
         .await
         .unwrap();
 
+    assert_eq!(dto_source.entries.len(), created_ids.len());
+
     let temp_file_dist = TempFile::new("json_export_dist");
     let provider_dist = JsonDataProvide::new(temp_file_dist.file_path.clone());
 

--- a/backend/tests/sqlite/mod.rs
+++ b/backend/tests/sqlite/mod.rs
@@ -2,7 +2,7 @@ use backend::*;
 use chrono::{TimeZone, Utc};
 
 async fn create_provider_with_two_entries() -> SqliteDataProvide {
-    let provider = SqliteDataProvide::create("sqlite::memory:").await.unwrap();
+    let provider = create_prvoider().await;
 
     let mut entry_draft_1 = EntryDraft::new(Utc::now(), String::from("Title 1"));
     entry_draft_1.content.push_str("Content entry 1");
@@ -16,6 +16,11 @@ async fn create_provider_with_two_entries() -> SqliteDataProvide {
     provider.add_entry(entry_draft_2).await.unwrap();
 
     provider
+}
+
+#[inline]
+async fn create_prvoider() -> SqliteDataProvide {
+    SqliteDataProvide::create("sqlite::memory:").await.unwrap()
 }
 
 #[tokio::test]
@@ -79,4 +84,27 @@ async fn update_entry() {
     assert_eq!(entries.len(), 2);
     assert_eq!(entries[0].content, String::from("Updated Content"));
     assert_eq!(entries[1].title, String::from("Updated Title"));
+}
+
+#[tokio::test]
+async fn text_export_import() {
+    let provider_source = create_provider_with_two_entries().await;
+
+    let created_ids = [1, 2];
+
+    let dto_source = provider_source
+        .get_export_object(&created_ids)
+        .await
+        .unwrap();
+
+    let provider_dist = create_prvoider().await;
+
+    provider_dist
+        .import_entries(dto_source.clone())
+        .await
+        .unwrap();
+
+    let dto_dist = provider_dist.get_export_object(&created_ids).await.unwrap();
+
+    assert_eq!(dto_source, dto_dist);
 }

--- a/backend/tests/sqlite/mod.rs
+++ b/backend/tests/sqlite/mod.rs
@@ -97,6 +97,8 @@ async fn text_export_import() {
         .await
         .unwrap();
 
+    assert_eq!(dto_source.entries.len(), created_ids.len());
+
     let provider_dist = create_prvoider().await;
 
     provider_dist

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -280,6 +280,10 @@ pub fn get_multi_select_keymaps() -> Vec<Keymap> {
             UICommand::MulSelDeleteEntries,
         ),
         Keymap::new(
+            Input::new(KeyCode::Char('>'), KeyModifiers::NONE),
+            UICommand::MulSelExportEntries,
+        ),
+        Keymap::new(
             Input::new(KeyCode::Char('?'), KeyModifiers::NONE),
             UICommand::ShowHelp,
         ),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -190,7 +190,7 @@ where
         self.data_provide
             .import_entries(entries_dto)
             .await
-            .map_err(|err| anyhow!("Error while importing the entrie. Error: {err}"))?;
+            .map_err(|err| anyhow!("Error while importing the entry. Error: {err}"))?;
 
         Ok(())
     }

--- a/src/app/runner.rs
+++ b/src/app/runner.rs
@@ -14,6 +14,7 @@ use backend::JsonDataProvide;
 use backend::SqliteDataProvide;
 
 use super::keymap::Input;
+use super::ui::ui_functions::render_message_centered;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum HandleInputReturnType {
@@ -124,17 +125,13 @@ async fn exec_pending_cmd<B: Backend, D: DataProvider>(
 ) -> anyhow::Result<()> {
     match pending_cmd {
         PendingCliCommand::ImportJorunals(file_path) => {
-            render_working(terminal, "Importing journals...");
+            terminal.draw(|f| render_message_centered(f, "Importing journals..."))?;
 
             app.import_entries(file_path).await?;
         }
     }
 
     Ok(())
-}
-
-fn render_working<B: Backend>(terminal: &mut Terminal<B>, working_text: &str) {
-    //TODO: render small message box with the working text inside it
 }
 
 fn draw_ui<B: Backend, D: DataProvider>(

--- a/src/app/runner.rs
+++ b/src/app/runner.rs
@@ -77,7 +77,9 @@ where
     let mut ui_components = UIComponents::new();
     let mut app = App::new(data_provider, settings);
     if let Some(cmd) = pending_cmd {
-        exec_pending_cmd(terminal, &app, cmd).await?;
+        if let Err(err) = exec_pending_cmd(terminal, &app, cmd).await {
+            ui_components.show_err_msg(err.to_string());
+        }
     }
     if let Err(err) = app.load_entries().await {
         ui_components.show_err_msg(err.to_string());

--- a/src/app/ui/commands/entries_list_cmd.rs
+++ b/src/app/ui/commands/entries_list_cmd.rs
@@ -234,7 +234,7 @@ pub fn export_entry_content<D: DataProvider>(ui_components: &mut UIComponents, a
         .current_entry_id
         .and_then(|id| app.entries.iter().find(|entry| entry.id == id))
     {
-        match ExportPopup::create(entry, app) {
+        match ExportPopup::create_entry_content(entry, app) {
             Ok(popup) => ui_components
                 .popup_stack
                 .push(Popup::Export(Box::new(popup))),

--- a/src/app/ui/commands/mod.rs
+++ b/src/app/ui/commands/mod.rs
@@ -41,6 +41,7 @@ pub enum UICommand {
     MulSelSelectNone,
     MulSelInverSelection,
     MulSelDeleteEntries,
+    MulSelExportEntries,
 }
 
 #[derive(Debug, Clone)]
@@ -137,6 +138,10 @@ impl UICommand {
                 "Delete selection",
                 "Delete selected journals in multi selection mode",
             ),
+            UICommand::MulSelExportEntries => CommandInfo::new(
+                "Export selection",
+                "Export selected journals to a transfer JSON file, which can be imported to other back-end files",
+            ),
         }
     }
 
@@ -171,6 +176,7 @@ impl UICommand {
             UICommand::MulSelSelectNone => exec_select_none(app),
             UICommand::MulSelInverSelection => exec_invert_selection(app),
             UICommand::MulSelDeleteEntries => exec_delete_selected_entries(ui_components, app),
+            UICommand::MulSelExportEntries => exec_export_selected_entries(ui_components, app),
         }
     }
 
@@ -225,6 +231,7 @@ impl UICommand {
             UICommand::MulSelDeleteEntries => {
                 continue_delete_selected_entries(ui_components, app, msg_box_result).await
             }
+            UICommand::MulSelExportEntries => not_implemented(),
         }
     }
 }

--- a/src/app/ui/commands/multi_select_cmd.rs
+++ b/src/app/ui/commands/multi_select_cmd.rs
@@ -2,8 +2,9 @@ use backend::DataProvider;
 
 use crate::app::{
     ui::{
+        export_popup::ExportPopup,
         msg_box::{MsgBoxActions, MsgBoxType},
-        MsgBoxResult,
+        MsgBoxResult, Popup,
     },
     App, HandleInputReturnType, UIComponents,
 };
@@ -144,6 +145,34 @@ pub async fn continue_delete_selected_entries<'a, D: DataProvider>(
             "{:?} not implemented for delete selected entries",
             msg_box_result
         ),
+    }
+
+    Ok(HandleInputReturnType::Handled)
+}
+
+pub fn exec_export_selected_entries<D: DataProvider>(
+    ui_components: &mut UIComponents,
+    app: &mut App<D>,
+) -> CmdResult {
+    debug_assert!(ui_components.entries_list.multi_select_mode);
+    debug_assert!(!ui_components.has_unsaved());
+
+    if app.selected_entries.is_empty() {
+        let msg = MsgBoxType::Info("No items have been selected".into());
+        let msg_action = MsgBoxActions::Ok;
+        ui_components.show_msg_box(msg, msg_action, None);
+
+        return Ok(HandleInputReturnType::Handled);
+    }
+
+    match ExportPopup::create_muti_select(app) {
+        Ok(popup) => ui_components
+            .popup_stack
+            .push(Popup::Export(Box::new(popup))),
+        Err(err) => ui_components.show_err_msg(format!(
+            "Error while creating export dialog.\n Err: {}",
+            err
+        )),
     }
 
     Ok(HandleInputReturnType::Handled)

--- a/src/app/ui/commands/multi_select_cmd.rs
+++ b/src/app/ui/commands/multi_select_cmd.rs
@@ -165,7 +165,7 @@ pub fn exec_export_selected_entries<D: DataProvider>(
         return Ok(HandleInputReturnType::Handled);
     }
 
-    match ExportPopup::create_muti_select(app) {
+    match ExportPopup::create_multi_select(app) {
         Ok(popup) => ui_components
             .popup_stack
             .push(Popup::Export(Box::new(popup))),

--- a/src/app/ui/export_popup/mod.rs
+++ b/src/app/ui/export_popup/mod.rs
@@ -19,22 +19,26 @@ use super::{
 
 const FOOTER_TEXT: &str = "Enter: confirm | Esc or <Ctrl-c>: Cancel";
 const FOOTER_MARGINE: u16 = 8;
+const DEFAULT_FILE_NAME: &str = "tjournal_export.json";
 
 pub struct ExportPopup<'a> {
     path_txt: TextArea<'a>,
     path_err_msg: String,
-    entry_id: u32,
-    entry_title: String,
+    entry_id: Option<u32>,
+    paragraph_text: String,
 }
 
 pub enum ExportPopupInputReturn {
     KeepPopup,
     Cancel,
-    Export(u32, PathBuf),
+    Export(PathBuf, Option<u32>),
 }
 
 impl<'a> ExportPopup<'a> {
-    pub fn create<D: DataProvider>(entry: &Entry, app: &App<D>) -> anyhow::Result<Self> {
+    pub fn create_entry_content<D: DataProvider>(
+        entry: &Entry,
+        app: &App<D>,
+    ) -> anyhow::Result<Self> {
         let mut default_path = if let Some(path) = &app.settings.export.default_path {
             path.clone()
         } else {
@@ -49,11 +53,45 @@ impl<'a> ExportPopup<'a> {
         let mut path_txt = TextArea::new(vec![default_path.to_string_lossy().to_string()]);
         path_txt.move_cursor(CursorMove::End);
 
+        let paragraph_text = format!("Journal: {}", entry.title.to_owned());
+
         let mut export_popup = ExportPopup {
             path_txt,
             path_err_msg: String::default(),
-            entry_id: entry.id,
-            entry_title: entry.title.to_owned(),
+            entry_id: Some(entry.id),
+            paragraph_text,
+        };
+
+        export_popup.validate_path();
+
+        Ok(export_popup)
+    }
+
+    pub fn create_muti_select<D: DataProvider>(app: &App<D>) -> anyhow::Result<Self> {
+        let mut default_path = if let Some(path) = &app.settings.export.default_path {
+            path.clone()
+        } else {
+            env::current_dir()?
+        };
+
+        // Add filename if it's not already defined
+        if default_path.extension().is_none() {
+            default_path.push(DEFAULT_FILE_NAME);
+        }
+
+        let mut path_txt = TextArea::new(vec![default_path.to_string_lossy().to_string()]);
+        path_txt.move_cursor(CursorMove::End);
+
+        let paragraph_text = format!(
+            "Export the selected {} journals",
+            app.selected_entries.len()
+        );
+
+        let mut export_popup = ExportPopup {
+            path_txt,
+            path_err_msg: String::default(),
+            entry_id: None,
+            paragraph_text,
         };
 
         export_popup.validate_path();
@@ -79,6 +117,10 @@ impl<'a> ExportPopup<'a> {
         self.path_err_msg.is_empty()
     }
 
+    fn is_multi_select_mode(&self) -> bool {
+        self.entry_id.is_none()
+    }
+
     pub fn render_widget<B: Backend>(&mut self, frame: &mut Frame<B>, area: Rect) {
         let mut area = centered_rect_exact_height(70, 11, area);
 
@@ -86,9 +128,13 @@ impl<'a> ExportPopup<'a> {
             area.height += 1;
         }
 
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .title("Export journal content");
+        let title = if self.is_multi_select_mode() {
+            "Export journals"
+        } else {
+            "Export journal content"
+        };
+
+        let block = Block::default().borders(Borders::ALL).title(title);
 
         frame.render_widget(Clear, area);
         frame.render_widget(block, area);
@@ -108,8 +154,8 @@ impl<'a> ExportPopup<'a> {
             )
             .split(area);
 
-        let journal_para_text = format!("Journal: {}", self.entry_title);
-        let journal_paragraph = Paragraph::new(journal_para_text).wrap(Wrap { trim: false });
+        let journal_paragraph =
+            Paragraph::new(self.paragraph_text.as_str()).wrap(Wrap { trim: false });
         frame.render_widget(journal_paragraph, chunks[0]);
 
         if self.path_err_msg.is_empty() {
@@ -167,6 +213,6 @@ impl<'a> ExportPopup<'a> {
             .parse()
             .expect("PathBuf from string should never fail");
 
-        ExportPopupInputReturn::Export(self.entry_id, path)
+        ExportPopupInputReturn::Export(path, self.entry_id)
     }
 }

--- a/src/app/ui/export_popup/mod.rs
+++ b/src/app/ui/export_popup/mod.rs
@@ -67,7 +67,7 @@ impl<'a> ExportPopup<'a> {
         Ok(export_popup)
     }
 
-    pub fn create_muti_select<D: DataProvider>(app: &App<D>) -> anyhow::Result<Self> {
+    pub fn create_multi_select<D: DataProvider>(app: &App<D>) -> anyhow::Result<Self> {
         let mut default_path = if let Some(path) = &app.settings.export.default_path {
             path.clone()
         } else {

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use backend::DataProvider;
 
 use self::{
@@ -242,28 +244,8 @@ impl<'a, 'b> UIComponents<'a> {
                         export_popup::ExportPopupInputReturn::Cancel => {
                             self.popup_stack.pop().expect("popup stack isn't empty");
                         }
-                        export_popup::ExportPopupInputReturn::Export(entry_id, path) => {
-                            match app.export_journal_content(entry_id, path.clone()).await {
-                                Ok(_) => {
-                                    self.popup_stack.pop().expect("popup stack isn't empty");
-
-                                    if app.settings.export.show_confirmation {
-                                        self.show_msg_box(
-                                            MsgBoxType::Info(format!(
-                                                "Journal content exported to file {}",
-                                                path.display()
-                                            )),
-                                            MsgBoxActions::Ok,
-                                            None,
-                                        );
-                                    }
-                                }
-                                Err(err) => {
-                                    self.show_err_msg(format!(
-                                        "Error while exporting journal content. Err: {err}",
-                                    ));
-                                }
-                            };
+                        export_popup::ExportPopupInputReturn::Export(path, entry_id) => {
+                            self.handle_export_popup_return(path, entry_id, app).await;
                         }
                     };
                 }
@@ -271,6 +253,46 @@ impl<'a, 'b> UIComponents<'a> {
             Ok(HandleInputReturnType::Handled)
         } else {
             Ok(HandleInputReturnType::NotFound)
+        }
+    }
+
+    #[inline]
+    async fn handle_export_popup_return<D: DataProvider>(
+        &mut self,
+        path: PathBuf,
+        entry_id: Option<u32>,
+        app: &mut App<D>,
+    ) {
+        if self.entries_list.multi_select_mode {
+            todo!()
+        } else {
+            match app
+                .export_journal_content(
+                    entry_id.expect("entry id must have a value in normal mode"),
+                    path.clone(),
+                )
+                .await
+            {
+                Ok(_) => {
+                    self.popup_stack.pop().expect("popup stack isn't empty");
+
+                    if app.settings.export.show_confirmation {
+                        self.show_msg_box(
+                            MsgBoxType::Info(format!(
+                                "Journal content exported to file {}",
+                                path.display()
+                            )),
+                            MsgBoxActions::Ok,
+                            None,
+                        );
+                    }
+                }
+                Err(err) => {
+                    self.show_err_msg(
+                        format!("Error while exporting journal content. Err: {err}",),
+                    );
+                }
+            };
         }
     }
 

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -37,7 +37,7 @@ mod export_popup;
 mod footer;
 mod help_popup;
 mod msg_box;
-mod ui_functions;
+pub mod ui_functions;
 
 pub use commands::UICommand;
 pub use msg_box::MsgBoxResult;

--- a/src/app/ui/ui_functions.rs
+++ b/src/app/ui/ui_functions.rs
@@ -1,4 +1,9 @@
-use tui::layout::{Constraint, Direction, Layout, Rect};
+use tui::{
+    backend::Backend,
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    widgets::{Block, BorderType, Borders, Clear, Paragraph},
+    Frame,
+};
 
 pub fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
     let popup_layout = Layout::default()
@@ -51,4 +56,53 @@ pub fn centered_rect_exact_height(percent_x: u16, height: u16, r: Rect) -> Rect 
             .as_ref(),
         )
         .split(popup_layout[1])[1]
+}
+
+pub fn centered_rect_exact_dimensions(width: u16, height: u16, r: Rect) -> Rect {
+    let height_percentage = ((height as f32 / r.height as f32) * 100f32) as u16;
+    let width_percentage = ((width as f32 / r.width as f32) * 100f32) as u16;
+    let popup_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(
+            [
+                Constraint::Percentage((100 - height_percentage) / 2),
+                Constraint::Length(height),
+                Constraint::Percentage((100 - height_percentage) / 2),
+            ]
+            .as_ref(),
+        )
+        .split(r);
+
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints(
+            [
+                Constraint::Percentage((100 - width_percentage) / 2),
+                Constraint::Percentage(width),
+                Constraint::Percentage((100 - width_percentage) / 2),
+            ]
+            .as_ref(),
+        )
+        .split(popup_layout[1])[1]
+}
+
+pub fn render_message_centered<B: Backend>(frame: &mut Frame<B>, message: &str) {
+    const TEXT_MARGINE: u16 = 4;
+    const HEIGHT_MARGINE: u16 = 2;
+
+    let width = message.len() as u16 + TEXT_MARGINE;
+    let height = message.lines().count() as u16 + HEIGHT_MARGINE;
+
+    let area = centered_rect_exact_dimensions(width, height, frame.size());
+
+    let paragraph = Paragraph::new(message)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded),
+        )
+        .alignment(Alignment::Center);
+
+    frame.render_widget(Clear, area);
+    frame.render_widget(paragraph, area);
 }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -8,13 +8,13 @@ use super::*;
 
 #[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
 pub enum CliCommand {
-    /// Print the current settings including the paths for the back-end files
+    /// Print the current settings including the paths for the back-end files.
     #[clap(visible_alias = "pc")]
     PrintConfig,
-    /// Import journals from the given JSON file path to the current back-end file
+    /// Import journals from the given transfer JSON file to the current back-end file.
     #[clap(visible_alias = "imj")]
     ImportJournals {
-        /// Path of JSON file
+        /// Path of the JSON file to import from.
         #[arg(short = 'p', long = "path", required = true, value_name = "FILE PATH")]
         file_path: PathBuf,
     },

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,0 +1,45 @@
+use std::path::PathBuf;
+
+use clap::Subcommand;
+
+use crate::settings::Settings;
+
+use super::*;
+
+#[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
+pub enum CliCommand {
+    /// Print the current settings including the paths for the back-end files
+    #[clap(visible_alias = "pc")]
+    PrintConfig,
+    /// Import journals from the given JSON file path to the current back-end file
+    #[clap(visible_alias = "imj")]
+    ImportJournals {
+        /// Path of JSON file
+        #[arg(short = 'p', long = "path", required = true, value_name = "FILE PATH")]
+        file_path: PathBuf,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PendingCliCommand {
+    ImportJorunals(PathBuf),
+}
+
+impl CliCommand {
+    pub async fn exec(self, settings: &mut Settings) -> anyhow::Result<CliResult> {
+        match self {
+            CliCommand::PrintConfig => exec_print_config(settings).await,
+            CliCommand::ImportJournals { file_path: path } => Ok(CliResult::PendingCommand(
+                PendingCliCommand::ImportJorunals(path),
+            )),
+        }
+    }
+}
+
+async fn exec_print_config(settings: &mut Settings) -> anyhow::Result<CliResult> {
+    let settings_text = settings.get_as_text()?;
+
+    println!("{settings_text}");
+
+    Ok(CliResult::Return)
+}


### PR DESCRIPTION
This PR closes #35 

It adds the following:
**Export**
- New command inside the multi select mode to export the selected journals to a transfer file in JSON format. Keybinding is `>`
- Command will open the export prompt where the path for the export file can be specified.
- The export prompt uses the same configurations as for exporting a single journal content
- the JSON file contains the journal + the version of the file, which will be helpful if other changes come in the future

**Import**
- The import happens via  a CLI command because it's easier to set path from the shell
- The program will import the journals from the file and the start as usual
- Import errors will be handled inside the program without panic