### PR TITLE
Changed:  improve GHA linting speed dramatically

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,16 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.5.3
+        with:
+          persist-credentials: false
+
+      - uses: devops-actions/actionlint@v0.1.1
+
   build:
 
     runs-on: ubuntu-latest
@@ -44,17 +54,3 @@ jobs:
       - uses: citation-file-format/cffconvert-github-action@2.0.0
         with:
           args: --validate
-
-  super-linter:
-    name: super-linter
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3.5.2
-        with:
-          persist-credentials: false
-
-      - env:
-          DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_GITHUB_ACTIONS: true
-        uses: super-linter/super-linter/slim@v5.0.0


### PR DESCRIPTION
This PR impressively reduces the time required for linting GitHub Action workflows without any loss of quality.  I tested this change in the repository of Aeruginous before and there, the time was reduced from about 2 minutes with GitHub's super-linter to *5 seconds* with this wrapper around actionlint's Docker image! :rocket:

The super-linter is undoubtedly very powerful as it ships with numerous linters to check almost every coding language; exceptions are Haskell, MATLAB, GNU Octave, CFF, Lex, Julia, Asymptote, and Nim, for example.  This wide range of covered languages is unfortunately also a drawback as we only access the GHA linting, at the moment, because we already have Clippy and rustfmt on the runner and do not need any further linters except for the CFF linter we call separately.  As the unused linters are downloaded anyway, the validation time of the GitHub Action workflows is unnecessarily increased, thus slowing down the CI in general.

The called Action this PR introduces only downloads the Docker image for actionlint, the sole linter we call from the super-linter package.  Thus, the image to download is *much* smaller and the workflow will succeed earlier.  As the actionlint Docker image also includes calls to shellcheck, the shell scripts defined in GHA workflows are still checked, as well.