### PR TITLE
Addd: Option to Use Git Configured Editor as External editor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,9 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -540,6 +543,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b989d6a7ca95a362cf2cfc5ad688b3a467be1f87e480b8dad07fee8c79b0044"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,6 +703,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
+name = "jobserver"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,12 +733,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.15.2+1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a80df2e11fb4a61f4ba2ab42dbe7f74468da143f1a75c74e11dee7c813f694fa"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ee889ecc9568871456d42f603d6a0ce59ff328d291063a45cbdf0036baf6db"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -1579,6 +1628,7 @@ dependencies = [
  "crossterm",
  "directories",
  "futures-util",
+ "git2",
  "log",
  "scopeguard",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ futures-util = { version = "0.3", default-features = false }
 tui = "0.19"
 tui-textarea = "0.2"
 scopeguard = "1.1.0"
+git2 = { version = "0.17.2", default-features = false }
 # Textarea crate supports ratatui but it doesn't provide a new version on crates.io to support it
 # crossterm = "0.26"
 # tui = { version = "0.20", package = "ratatui" }

--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ Here is a sample of the settings in the `config.toml` file:
 
 ```toml
 backend_type = "Sqlite"   # available options: Json, Sqlite. Default value: Sqlite.
-# Set the external terminal editor to use from withing the app. If the value isn't set the app will use the environment varialbes VISUAL, EDITOR then it'll try with vi.  
+# Set the external terminal editor to use from withing the app.
+# If the value isn't set the app will try to retrieve the editor from git global configurations then It'll try with the environment varialbes VISUAL, EDITOR then it'll fallback to vi.  
 external_editor = "nvim"
 
 [export]


### PR DESCRIPTION
This PR closes #38 

It adds the the option to use git core editor from git global configurations.
Retrieving the editor now follows these priorities:
App config >> Git config >> VISUAL env variable >> EDITOR env variable >> vi