### PR TITLE
Fixed: Release GitHub action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/setup-rust@v1
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable


### PR DESCRIPTION
This PR should fix failing build in the release GitHub action.

It updates the GitHub action to install rust toolchain since the current one is deprecated 