### PR TITLE
Changed: Keep journals list in focus after closing the external editor

### DIFF
--- a/src/app/ui/commands/entries_list_cmd.rs
+++ b/src/app/ui/commands/entries_list_cmd.rs
@@ -307,7 +307,7 @@ pub async fn edit_in_external_editor<'a, D: DataProvider>(
         if file_path.exists() {
             let new_content = fs::read_to_string(&file_path).await?;
             ui_components.editor.set_entry_content(&new_content, app);
-            ui_components.change_active_control(ControlType::EntryContentTxt);
+            ui_components.change_active_control(ControlType::EntriesList);
         }
     }
 


### PR DESCRIPTION
It feels more intuitive to keep the focus in the journals list after finish editing journal's content in external editor 