### PR TITLE
Changed: Add Filter Keybindings To Footer

### DIFF
--- a/src/app/ui/footer.rs
+++ b/src/app/ui/footer.rs
@@ -1,59 +1,64 @@
+use backend::DataProvider;
 use tui::{
     backend::Backend,
     layout::{Alignment, Rect},
     style::Style,
-    text::{Span, Spans},
-    widgets::{Block, Borders, Paragraph},
+    widgets::{Block, Borders, Paragraph, Wrap},
     Frame,
 };
 
-use crate::app::keymap::Keymap;
+use crate::app::{keymap::Keymap, App};
 
-use super::{UICommand, UIComponents};
+use super::{ControlType, UICommand, UIComponents};
 
-pub fn render_footer<B: Backend>(frame: &mut Frame<B>, area: Rect, ui_components: &UIComponents) {
+const SEPARATOR: &str = " | ";
+
+pub fn render_footer<B: Backend, D: DataProvider>(
+    frame: &mut Frame<B>,
+    area: Rect,
+    ui_components: &UIComponents,
+    app: &App<D>,
+) {
     let (edior_mode, multi_select_mode) = (
         ui_components.editor.is_insert_mode(),
         ui_components.entries_list.multi_select_mode,
     );
-    let spans = match (edior_mode, multi_select_mode) {
-        (true, false) => get_editor_mode_spans(ui_components),
-        (false, true) => get_multi_select_spans(ui_components),
-        _ => get_standard_spans(ui_components),
+    let footer_text = match (edior_mode, multi_select_mode) {
+        (true, false) => get_editor_mode_text(ui_components),
+        (false, true) => get_multi_select_text(ui_components),
+        _ => get_standard_text(ui_components, app),
     };
-    let footer = Paragraph::new(spans).alignment(Alignment::Left).block(
-        Block::default()
-            .borders(Borders::NONE)
-            .style(Style::default()),
-    );
+    let footer = Paragraph::new(footer_text)
+        .alignment(Alignment::Left)
+        .wrap(Wrap { trim: false })
+        .block(
+            Block::default()
+                .borders(Borders::NONE)
+                .style(Style::default()),
+        );
 
     frame.render_widget(footer, area);
 }
 
-fn get_editor_mode_spans<'a>(ui_components: &'a UIComponents) -> Spans<'a> {
+fn get_editor_mode_text(ui_components: &UIComponents) -> String {
     let exit_editor_mode_keymap: Vec<_> = ui_components
         .editor_keymaps
         .iter()
         .filter(|keymap| keymap.command == UICommand::FinishEditEntryContent)
         .collect();
 
-    Spans::from(vec![
-        get_keymap_spans(exit_editor_mode_keymap),
-        Span::raw(" | Edit using Emacs motions"),
-    ])
+    format!(
+        "{}{} Edit using Emacs motions",
+        get_keymap_text(exit_editor_mode_keymap),
+        SEPARATOR
+    )
 }
 
-fn get_standard_spans<'a>(ui_components: &'a UIComponents) -> Spans<'a> {
+fn get_standard_text<D: DataProvider>(ui_components: &UIComponents, app: &App<D>) -> String {
     let close_keymap: Vec<_> = ui_components
         .global_keymaps
         .iter()
         .filter(|keymap| keymap.command == UICommand::Quit)
-        .collect();
-
-    let help_keymap: Vec<_> = ui_components
-        .global_keymaps
-        .iter()
-        .filter(|keymap| keymap.command == UICommand::ShowHelp)
         .collect();
 
     let enter_editor_keymap: Vec<_> = ui_components
@@ -62,16 +67,43 @@ fn get_standard_spans<'a>(ui_components: &'a UIComponents) -> Spans<'a> {
         .filter(|keymap| keymap.command == UICommand::StartEditEntryContent)
         .collect();
 
-    Spans::from(vec![
-        get_keymap_spans(close_keymap),
-        Span::raw(" | "),
-        get_keymap_spans(enter_editor_keymap),
-        Span::raw(" | "),
-        get_keymap_spans(help_keymap),
-    ])
+    let mut footer_parts = vec![
+        get_keymap_text(close_keymap),
+        get_keymap_text(enter_editor_keymap),
+    ];
+
+    if ui_components.active_control == ControlType::EntriesList {
+        if app.filter.is_none() {
+            let show_fiter_keymap: Vec<_> = ui_components
+                .entries_list_keymaps
+                .iter()
+                .filter(|keymap| keymap.command == UICommand::ShowFilter)
+                .collect();
+
+            footer_parts.push(get_keymap_text(show_fiter_keymap));
+        } else {
+            let reset_fiter_keymap: Vec<_> = ui_components
+                .entries_list_keymaps
+                .iter()
+                .filter(|keymap| keymap.command == UICommand::ResetFilter)
+                .collect();
+
+            footer_parts.push(get_keymap_text(reset_fiter_keymap));
+        }
+    }
+
+    let help_keymap: Vec<_> = ui_components
+        .global_keymaps
+        .iter()
+        .filter(|keymap| keymap.command == UICommand::ShowHelp)
+        .collect();
+
+    footer_parts.push(get_keymap_text(help_keymap));
+
+    footer_parts.join(SEPARATOR)
 }
 
-fn get_multi_select_spans<'a>(ui_components: &'a UIComponents) -> Spans<'a> {
+fn get_multi_select_text(ui_components: &UIComponents) -> String {
     let leave_keymap: Vec<_> = ui_components
         .multi_select_keymaps
         .iter()
@@ -84,14 +116,12 @@ fn get_multi_select_spans<'a>(ui_components: &'a UIComponents) -> Spans<'a> {
         .filter(|keymap| keymap.command == UICommand::ShowHelp)
         .collect();
 
-    Spans::from(vec![
-        get_keymap_spans(leave_keymap),
-        Span::raw(" | "),
-        get_keymap_spans(help_keymap),
-    ])
+    let parts = vec![get_keymap_text(leave_keymap), get_keymap_text(help_keymap)];
+
+    parts.join(SEPARATOR)
 }
 
-fn get_keymap_spans(keymaps: Vec<&Keymap>) -> Span {
+fn get_keymap_text(keymaps: Vec<&Keymap>) -> String {
     let cmd_text = keymaps
         .first()
         .map(|keymap| keymap.command.get_info().name)
@@ -102,8 +132,5 @@ fn get_keymap_spans(keymaps: Vec<&Keymap>) -> Span {
         .map(|keymap| format!("'{}'", keymap.key))
         .collect();
 
-    Span::styled(
-        format!("{}: {}", cmd_text, keys.join(",")),
-        Style::default(),
-    )
+    format!("{}: {}", cmd_text, keys.join(","))
 }

--- a/src/app/ui/footer.rs
+++ b/src/app/ui/footer.rs
@@ -74,21 +74,21 @@ fn get_standard_text<D: DataProvider>(ui_components: &UIComponents, app: &App<D>
 
     if ui_components.active_control == ControlType::EntriesList {
         if app.filter.is_none() {
-            let show_fiter_keymap: Vec<_> = ui_components
+            let show_filter_keymap: Vec<_> = ui_components
                 .entries_list_keymaps
                 .iter()
                 .filter(|keymap| keymap.command == UICommand::ShowFilter)
                 .collect();
 
-            footer_parts.push(get_keymap_text(show_fiter_keymap));
+            footer_parts.push(get_keymap_text(show_filter_keymap));
         } else {
-            let reset_fiter_keymap: Vec<_> = ui_components
+            let reset_filter_keymap: Vec<_> = ui_components
                 .entries_list_keymaps
                 .iter()
                 .filter(|keymap| keymap.command == UICommand::ResetFilter)
                 .collect();
 
-            footer_parts.push(get_keymap_text(reset_fiter_keymap));
+            footer_parts.push(get_keymap_text(reset_filter_keymap));
         }
     }
 

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -124,7 +124,7 @@ impl<'a, 'b> UIComponents<'a> {
             .constraints([Constraint::Min(2), Constraint::Length(1)].as_ref())
             .split(f.size());
 
-        render_footer(f, chunks[1], self);
+        render_footer(f, chunks[1], self, app);
 
         let entries_chunks = Layout::default()
             .direction(Direction::Horizontal)


### PR DESCRIPTION
This PR adds the keybindings to show and reset the filter in the app main footer.

It adds some improvements and refactoring to the footer source code