### PR TITLE
Added: Search Functions in Filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ TUI-Journal is a terminal-based application written in Rust that allows you to w
 - Create, edit, and delete entries easily.
 - Edit journal content with the built-in editor or use your favourite terminal text editor from withing the app.
 - Add custom tags to the journals and use them in the built-in filter.
+- Search functions for journals title and content in the built-in filter.
 - Control many journals at once via the multi-select mode
 - Keybindings is a combination of VIM and Emacs motions (VIM for navigation and Emacs for editing texts in edit-mode).
 - Export and Import journals between different back-end files.
@@ -51,7 +52,7 @@ TUI-Journal is a terminal-based application written in Rust that allows you to w
 - [ ]  RESTful back-end server with a client in the app.
 #### Application:
 - [x]  Edit journals content with external text editor from withing the app.
-- [ ]  Filter & Search functionalities.
+- [x]  Filter & Search functionalities.
 - [ ]  Customize themes and keybindings.
 - [ ]  Load entries as chunks for better performance.
 ## Installation

--- a/src/app/filter/criterion.rs
+++ b/src/app/filter/criterion.rs
@@ -3,6 +3,8 @@ use backend::Entry;
 #[derive(Debug, Clone)]
 pub enum FilterCritrion {
     Tag(String),
+    Title(String),
+    Content(String),
 }
 
 impl FilterCritrion {
@@ -10,6 +12,8 @@ impl FilterCritrion {
     pub fn check_entry(&self, entry: &Entry) -> bool {
         match self {
             FilterCritrion::Tag(tag) => entry.tags.contains(tag),
+            FilterCritrion::Title(search) => entry.title.contains(search),
+            FilterCritrion::Content(search) => entry.content.contains(search),
         }
     }
 }

--- a/src/app/filter/mod.rs
+++ b/src/app/filter/mod.rs
@@ -1,4 +1,5 @@
 use backend::Entry;
+use rayon::prelude::*;
 
 pub mod criterion;
 
@@ -29,8 +30,8 @@ impl Filter {
     /// Checks if the entry meets the filter criteria
     pub fn check_entry(&self, entry: &Entry) -> bool {
         match self.relation {
-            CriteriaRelation::And => self.critria.iter().all(|cr| cr.check_entry(entry)),
-            CriteriaRelation::Or => self.critria.iter().any(|cr| cr.check_entry(entry)),
+            CriteriaRelation::And => self.critria.par_iter().all(|cr| cr.check_entry(entry)),
+            CriteriaRelation::Or => self.critria.par_iter().any(|cr| cr.check_entry(entry)),
         }
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -250,9 +250,10 @@ where
             let all_tags = self.get_all_tags();
             let filter = self.filter.as_mut().unwrap();
 
-            filter.critria.retain(|cr| {
-                let FilterCritrion::Tag(tag) = cr;
-                all_tags.contains(tag)
+            filter.critria.retain(|cr| match cr {
+                FilterCritrion::Tag(tag) => all_tags.contains(tag),
+                FilterCritrion::Title(_) => true,
+                FilterCritrion::Content(_) => true,
             });
 
             if filter.critria.is_empty() {

--- a/src/app/ui/entries_list/mod.rs
+++ b/src/app/ui/entries_list/mod.rs
@@ -115,7 +115,7 @@ impl<'a> EntriesList {
             .collect();
 
         let list = List::new(items)
-            .block(self.get_list_block())
+            .block(self.get_list_block(app.filter.is_some()))
             .highlight_style(
                 Style::default()
                     .fg(Color::Black)
@@ -132,6 +132,7 @@ impl<'a> EntriesList {
         frame: &mut Frame<B>,
         area: Rect,
         list_keymaps: &[Keymap],
+        has_filter: bool,
     ) {
         let keys_text: Vec<String> = list_keymaps
             .iter()
@@ -148,17 +149,18 @@ impl<'a> EntriesList {
         let place_holder = Paragraph::new(place_holder_text)
             .wrap(Wrap { trim: false })
             .alignment(Alignment::Center)
-            .block(self.get_list_block());
+            .block(self.get_list_block(has_filter));
 
         frame.render_widget(place_holder, area);
     }
 
     #[inline]
-    fn get_list_block(&self) -> Block<'a> {
-        let title = if self.multi_select_mode {
-            "Journals - Multi-Select"
-        } else {
-            "Journals"
+    fn get_list_block(&self, has_filter: bool) -> Block<'a> {
+        let title = match (self.multi_select_mode, has_filter) {
+            (true, true) => "Journals - Multi-Select - Filtered",
+            (true, false) => "Journals - Multi-Select",
+            (false, true) => "Journals - Filtered",
+            (false, false) => "Journals",
         };
 
         let border_style = match (self.is_active, self.multi_select_mode) {
@@ -186,7 +188,7 @@ impl<'a> EntriesList {
         list_keymaps: &[Keymap],
     ) {
         if app.get_active_entries().next().is_none() {
-            self.render_place_holder(frame, area, list_keymaps);
+            self.render_place_holder(frame, area, list_keymaps, app.filter.is_some());
         } else {
             self.render_list(frame, app, area);
         }

--- a/src/app/ui/filter_popup/mod.rs
+++ b/src/app/ui/filter_popup/mod.rs
@@ -18,7 +18,7 @@ use crate::app::{
 use super::ui_functions::centered_rect;
 
 const FOOTER_TEXT: &str = r"Tab: Change focused control | Enter or <Ctrl-m>: Confirm | Esc or <Ctrl-c>: Cancel | <Ctrl-r>: Change Matching Logic | <Space>: Tags Toggle Selected";
-const FOOTER_MARGINE: u16 = 8;
+const FOOTER_MARGINE: usize = 8;
 const ACTIVE_BORDER_COLOR: Color = Color::LightYellow;
 
 pub struct FilterPopup<'a> {
@@ -92,11 +92,9 @@ impl<'a> FilterPopup<'a> {
         frame.render_widget(Clear, area);
         frame.render_widget(block, area);
 
-        let footer_height = if area.width < FOOTER_TEXT.len() as u16 + FOOTER_MARGINE {
-            2
-        } else {
-            1
-        };
+        let footer_height = textwrap::fill(FOOTER_TEXT, (area.width as usize) - FOOTER_MARGINE)
+            .lines()
+            .count();
 
         let chunks = Layout::default()
             .direction(Direction::Vertical)
@@ -108,7 +106,7 @@ impl<'a> FilterPopup<'a> {
                     Constraint::Length(3),
                     Constraint::Length(3),
                     Constraint::Min(4),
-                    Constraint::Length(footer_height),
+                    Constraint::Length(footer_height.try_into().unwrap()),
                 ]
                 .as_ref(),
             )

--- a/src/app/ui/filter_popup/mod.rs
+++ b/src/app/ui/filter_popup/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use crossterm::event::{KeyCode, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use tui::{
     backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -8,6 +8,7 @@ use tui::{
     widgets::{Block, BorderType, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
     Frame,
 };
+use tui_textarea::{CursorMove, TextArea};
 
 use crate::app::{
     filter::{CriteriaRelation, Filter, FilterCritrion},
@@ -16,14 +17,25 @@ use crate::app::{
 
 use super::ui_functions::centered_rect;
 
-const FOOTER_TEXT: &str = r"Enter or <Ctrl-m>: Confirm | r: Change Matching Logic | <Space>: Toggle Selected | Esc, q or <Ctrl-c>: Cancel";
+const FOOTER_TEXT: &str = r"Tab: Change focused control | Enter or <Ctrl-m>: Confirm | Esc or <Ctrl-c>: Cancel | <Ctrl-r>: Change Matching Logic | <Space>: Tags Toggle Selected";
 const FOOTER_MARGINE: u16 = 8;
+const ACTIVE_BORDER_COLOR: Color = Color::LightYellow;
 
-pub struct FilterPopup {
-    state: ListState,
+pub struct FilterPopup<'a> {
+    active_control: FilterControl,
+    tags_state: ListState,
     tags: Vec<String>,
     relation: CriteriaRelation,
     selected_tags: HashSet<String>,
+    title_txt: TextArea<'a>,
+    content_txt: TextArea<'a>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum FilterControl {
+    TitleTxt,
+    ContentTxt,
+    TagsList,
 }
 
 pub enum FilterPopupReturn {
@@ -32,25 +44,40 @@ pub enum FilterPopupReturn {
     Apply(Option<Filter>),
 }
 
-impl FilterPopup {
+impl<'a> FilterPopup<'a> {
     pub fn new(tags: Vec<String>, filter: Option<Filter>) -> Self {
         let filter = filter.unwrap_or_default();
 
         let relation = filter.relation;
 
-        let selected_tags = filter
-            .critria
-            .into_iter()
-            .map(|cr| match cr {
-                FilterCritrion::Tag(tag) => tag,
-            })
-            .collect();
+        let mut selected_tags = HashSet::new();
+        let mut title_text = String::default();
+        let mut content_text = String::default();
+
+        filter.critria.into_iter().for_each(|cr| match cr {
+            FilterCritrion::Tag(tag) => {
+                selected_tags.insert(tag);
+            }
+            FilterCritrion::Title(title_search) => title_text = title_search,
+            FilterCritrion::Content(content_search) => content_text = content_search,
+        });
+
+        let mut title_txt = TextArea::new(vec![title_text]);
+        title_txt.move_cursor(CursorMove::End);
+
+        let mut content_txt = TextArea::new(vec![content_text]);
+        content_txt.move_cursor(CursorMove::End);
+
+        let active_control = FilterControl::TitleTxt;
 
         let mut filter_popup = FilterPopup {
-            state: ListState::default(),
+            active_control,
+            tags_state: ListState::default(),
             tags,
             relation,
             selected_tags,
+            title_txt,
+            content_txt,
         };
 
         filter_popup.cycle_next_tag();
@@ -59,7 +86,7 @@ impl FilterPopup {
     }
 
     pub fn render_widget<B: Backend>(&mut self, frame: &mut Frame<B>, area: Rect) {
-        let area = centered_rect(70, 70, area);
+        let area = centered_rect(70, 80, area);
 
         let block = Block::default().borders(Borders::ALL).title("Filter");
         frame.render_widget(Clear, area);
@@ -78,6 +105,8 @@ impl FilterPopup {
             .constraints(
                 [
                     Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Length(3),
                     Constraint::Min(4),
                     Constraint::Length(footer_height),
                 ]
@@ -85,6 +114,21 @@ impl FilterPopup {
             )
             .split(area);
 
+        self.render_relations(frame, chunks[0]);
+
+        self.render_text_boxes(frame, chunks[1], chunks[2]);
+
+        if self.tags.is_empty() {
+            self.render_tags_place_holder(frame, chunks[3]);
+        } else {
+            self.render_tags_list(frame, chunks[3]);
+        }
+
+        self.render_footer(frame, chunks[4]);
+    }
+
+    #[inline]
+    fn render_relations<B: Backend>(&mut self, frame: &mut Frame<B>, area: Rect) {
         let relation_text = match self.relation {
             CriteriaRelation::And => "Journals must meet all criteria",
             CriteriaRelation::Or => "Journals must meet any of the criteria",
@@ -99,26 +143,51 @@ impl FilterPopup {
                     .title("Matching Logic"),
             );
 
-        frame.render_widget(relation, chunks[0]);
-
-        if self.tags.is_empty() {
-            self.render_tags_place_holder(frame, chunks[1]);
-        } else {
-            self.render_tags_list(frame, chunks[1]);
-        }
-
-        let footer = Paragraph::new(FOOTER_TEXT)
-            .alignment(Alignment::Center)
-            .wrap(Wrap { trim: false })
-            .block(
-                Block::default()
-                    .borders(Borders::NONE)
-                    .style(Style::default()),
-            );
-
-        frame.render_widget(footer, chunks[2]);
+        frame.render_widget(relation, area);
     }
 
+    #[inline]
+    fn render_text_boxes<B: Backend>(
+        &mut self,
+        frame: &mut Frame<B>,
+        title_area: Rect,
+        content_area: Rect,
+    ) {
+        let active_cursor_style = Style::default().bg(Color::White).fg(Color::Black);
+        let deactivate_cursor_style = Style::default().bg(Color::Reset);
+
+        let mut title_txt_block = Block::default().title("Title").borders(Borders::ALL);
+        let mut content_txt_block = Block::default().title("Content").borders(Borders::ALL);
+
+        match self.active_control {
+            FilterControl::TitleTxt => {
+                self.title_txt.set_cursor_style(active_cursor_style);
+                self.content_txt.set_cursor_style(deactivate_cursor_style);
+                title_txt_block = title_txt_block.style(Style::default().fg(ACTIVE_BORDER_COLOR));
+            }
+            FilterControl::ContentTxt => {
+                self.title_txt.set_cursor_style(deactivate_cursor_style);
+                self.content_txt.set_cursor_style(active_cursor_style);
+                content_txt_block =
+                    content_txt_block.style(Style::default().fg(ACTIVE_BORDER_COLOR));
+            }
+            FilterControl::TagsList => {
+                self.title_txt.set_cursor_style(deactivate_cursor_style);
+                self.content_txt.set_cursor_style(deactivate_cursor_style);
+            }
+        }
+
+        self.title_txt.set_cursor_line_style(Style::default());
+        self.content_txt.set_cursor_line_style(Style::default());
+
+        self.title_txt.set_block(title_txt_block);
+        self.content_txt.set_block(content_txt_block);
+
+        frame.render_widget(self.title_txt.widget(), title_area);
+        frame.render_widget(self.content_txt.widget(), content_area);
+    }
+
+    #[inline]
     fn render_tags_list<B: Backend>(&mut self, frame: &mut Frame<B>, area: Rect) {
         let items: Vec<ListItem> = self
             .tags
@@ -134,7 +203,7 @@ impl FilterPopup {
                             .add_modifier(Modifier::BOLD),
                     )
                 } else {
-                    (tag.to_owned(), Style::default())
+                    (tag.to_owned(), Style::default().fg(Color::Reset))
                 };
 
                 ListItem::new(tag_text).style(style)
@@ -142,58 +211,111 @@ impl FilterPopup {
             .collect();
 
         let list = List::new(items)
-            .block(FilterPopup::get_list_block())
+            .block(self.get_list_block())
             .highlight_style(Style::default().fg(Color::Black).bg(Color::LightGreen))
             .highlight_symbol(">> ");
 
-        frame.render_stateful_widget(list, area, &mut self.state);
+        frame.render_stateful_widget(list, area, &mut self.tags_state);
     }
 
+    #[inline]
     fn render_tags_place_holder<B: Backend>(&mut self, frame: &mut Frame<B>, area: Rect) {
         let place_holder_text = String::from("\nNo journals with tags provided");
 
         let place_holder = Paragraph::new(place_holder_text)
             .wrap(Wrap { trim: false })
             .alignment(Alignment::Center)
-            .block(FilterPopup::get_list_block());
+            .block(self.get_list_block());
 
         frame.render_widget(place_holder, area);
     }
 
     #[inline]
-    fn get_list_block<'a>() -> Block<'a> {
+    fn get_list_block<'b>(&self) -> Block<'b> {
+        let style = match self.active_control {
+            FilterControl::TagsList => Style::default().fg(ACTIVE_BORDER_COLOR),
+            _ => Style::default(),
+        };
         Block::default()
             .borders(Borders::ALL)
             .title("Tags")
             .border_type(BorderType::Rounded)
+            .style(style)
+    }
+
+    #[inline]
+    fn render_footer<B: Backend>(&mut self, frame: &mut Frame<B>, area: Rect) {
+        let footer = Paragraph::new(FOOTER_TEXT)
+            .alignment(Alignment::Center)
+            .wrap(Wrap { trim: false })
+            .block(
+                Block::default()
+                    .borders(Borders::NONE)
+                    .style(Style::default()),
+            );
+
+        frame.render_widget(footer, area);
     }
 
     pub fn handle_input(&mut self, input: &Input) -> FilterPopupReturn {
         let has_control = input.modifiers.contains(KeyModifiers::CONTROL);
 
-        match input.key_code {
-            KeyCode::Char('j') | KeyCode::Down => {
-                self.cycle_next_tag();
-                FilterPopupReturn::KeepPopup
+        if self.active_control != FilterControl::TagsList {
+            match input.key_code {
+                KeyCode::Tab => self.cycle_next_control(),
+                KeyCode::Esc => FilterPopupReturn::Cancel,
+                KeyCode::Char('c') if has_control => FilterPopupReturn::Cancel,
+                KeyCode::Enter => self.confirm(),
+                KeyCode::Char('m') if has_control => self.confirm(),
+                KeyCode::Char('r') if has_control => {
+                    self.change_relation();
+                    FilterPopupReturn::KeepPopup
+                }
+                _ => {
+                    match self.active_control {
+                        FilterControl::TitleTxt => self.title_txt.input(KeyEvent::from(input)),
+                        FilterControl::ContentTxt => self.content_txt.input(KeyEvent::from(input)),
+                        FilterControl::TagsList => unreachable!("Tags List is unreachable here"),
+                    };
+                    FilterPopupReturn::KeepPopup
+                }
             }
-            KeyCode::Char('k') | KeyCode::Up => {
-                self.cycle_prev_tag();
-                FilterPopupReturn::KeepPopup
+        } else {
+            match input.key_code {
+                KeyCode::Tab => self.cycle_next_control(),
+                KeyCode::Char('j') | KeyCode::Down => {
+                    self.cycle_next_tag();
+                    FilterPopupReturn::KeepPopup
+                }
+                KeyCode::Char('k') | KeyCode::Up => {
+                    self.cycle_prev_tag();
+                    FilterPopupReturn::KeepPopup
+                }
+                KeyCode::Char(' ') => {
+                    self.toggle_selected();
+                    FilterPopupReturn::KeepPopup
+                }
+                KeyCode::Char('r') => {
+                    self.change_relation();
+                    FilterPopupReturn::KeepPopup
+                }
+                KeyCode::Esc | KeyCode::Char('q') => FilterPopupReturn::Cancel,
+                KeyCode::Char('c') if has_control => FilterPopupReturn::Cancel,
+                KeyCode::Enter => self.confirm(),
+                KeyCode::Char('m') if has_control => self.confirm(),
+                _ => FilterPopupReturn::KeepPopup,
             }
-            KeyCode::Char(' ') => {
-                self.toggle_selected();
-                FilterPopupReturn::KeepPopup
-            }
-            KeyCode::Char('r') => {
-                self.change_relation();
-                FilterPopupReturn::KeepPopup
-            }
-            KeyCode::Esc | KeyCode::Char('q') => FilterPopupReturn::Cancel,
-            KeyCode::Char('c') if has_control => FilterPopupReturn::Cancel,
-            KeyCode::Enter => self.confirm(),
-            KeyCode::Char('m') if has_control => self.confirm(),
-            _ => FilterPopupReturn::KeepPopup,
         }
+    }
+
+    fn cycle_next_control(&mut self) -> FilterPopupReturn {
+        self.active_control = match self.active_control {
+            FilterControl::TitleTxt => FilterControl::ContentTxt,
+            FilterControl::ContentTxt => FilterControl::TagsList,
+            FilterControl::TagsList => FilterControl::TitleTxt,
+        };
+
+        FilterPopupReturn::KeepPopup
     }
 
     #[inline]
@@ -204,12 +326,12 @@ impl FilterPopup {
 
         let last_index = self.tags.len() - 1;
         let new_index = self
-            .state
+            .tags_state
             .selected()
             .map(|idx| if idx >= last_index { 0 } else { idx + 1 })
             .unwrap_or(0);
 
-        self.state.select(Some(new_index));
+        self.tags_state.select(Some(new_index));
     }
 
     #[inline]
@@ -220,12 +342,12 @@ impl FilterPopup {
 
         let last_index = self.tags.len() - 1;
         let new_index = self
-            .state
+            .tags_state
             .selected()
             .map(|idx| idx.checked_sub(1).unwrap_or(last_index))
             .unwrap_or(last_index);
 
-        self.state.select(Some(new_index));
+        self.tags_state.select(Some(new_index));
     }
 
     #[inline]
@@ -238,7 +360,7 @@ impl FilterPopup {
 
     #[inline]
     fn toggle_selected(&mut self) {
-        if let Some(idx) = self.state.selected() {
+        if let Some(idx) = self.tags_state.selected() {
             let tag = self
                 .tags
                 .get(idx)
@@ -253,21 +375,41 @@ impl FilterPopup {
     }
 
     fn confirm(&self) -> FilterPopupReturn {
-        if self.selected_tags.is_empty() {
-            return FilterPopupReturn::Apply(None);
-        }
-
-        let critria: Vec<_> = self
+        let mut critria: Vec<_> = self
             .selected_tags
             .iter()
             .map(|tag| FilterCritrion::Tag(tag.into()))
             .collect();
 
-        let filter = Filter {
-            relation: self.relation,
-            critria,
-        };
+        let title_filter = self
+            .title_txt
+            .lines()
+            .first()
+            .expect("Title TextBox has one line");
 
-        FilterPopupReturn::Apply(Some(filter))
+        if !title_filter.is_empty() {
+            critria.push(FilterCritrion::Title(title_filter.to_owned()));
+        }
+
+        let content_filter = self
+            .content_txt
+            .lines()
+            .first()
+            .expect("Content TextBox has one line");
+
+        if !content_filter.is_empty() {
+            critria.push(FilterCritrion::Content(content_filter.to_owned()));
+        }
+
+        if critria.is_empty() {
+            FilterPopupReturn::Apply(None)
+        } else {
+            let filter = Filter {
+                relation: self.relation,
+                critria,
+            };
+
+            FilterPopupReturn::Apply(Some(filter))
+        }
     }
 }

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -261,6 +261,12 @@ impl<'a, 'b> UIComponents<'a> {
                     filter_popup::FilterPopupReturn::Apply(filter) => {
                         app.apply_filter(filter);
                         self.popup_stack.pop().expect("popup stack isn't empty");
+
+                        // This fixes the bug: Entry will not be highlighted when the result of the filter is one entry only
+                        if app.get_active_entries().count() == 1 {
+                            let entry_id = app.get_active_entries().next().map(|entrie| entrie.id);
+                            self.set_current_entry(entry_id, app);
+                        }
                     }
                 },
             }

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -60,7 +60,7 @@ pub enum Popup<'a> {
     Entry(Box<EntryPopup<'a>>),
     MsgBox(Box<MsgBox>),
     Export(Box<ExportPopup<'a>>),
-    Filter(Box<FilterPopup>),
+    Filter(Box<FilterPopup<'a>>),
 }
 
 pub struct UIComponents<'a> {


### PR DESCRIPTION
This PR closes #27

- It adds two filter functions to search for the journal titles and content.
- Filter Prompt have now two text boxes for the title and content beside the tags
- This allow the users to apply relatively complex filter in the cost of adding more keystrokes for the simple cases.
- Applying the filter runs in parallel now to achieve the best performance.
- I fixed a mini bug when the result of the filter query one journals only then it will be not highlighted
- Added text indicator to journals title when a filter is applied 