### PR TITLE
Added: Create Cleanup Cache GitHub Action

### DIFF
--- a/.github/workflows/cleanup_cache.yml
+++ b/.github/workflows/cleanup_cache.yml
@@ -1,0 +1,33 @@
+name: cleanup caches by a branch
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+          
+          REPO=${{ github.repository }}
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys. 
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cleanup_cache.yml
+++ b/.github/workflows/cleanup_cache.yml
@@ -16,17 +16,17 @@ jobs:
           gh extension install actions/gh-actions-cache
           
           REPO=${{ github.repository }}
-          BRANCH=refs/pull/${{ github.event.pull_request.number }}/merge"
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
 
           echo "Fetching list of cache key"
-          cacheKeysForPR="$(gh actions-cache list -R "$REPO" -B "$BRANCH" | cut -f 1 )"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
 
           ## Setting this to not fail the workflow while deleting cache keys. 
           set +e
           echo "Deleting caches..."
           for cacheKey in $cacheKeysForPR
           do
-              gh actions-cache delete "$cacheKey" -R $REPO -B "$BRANCH" --confirm
+              gh actions-cache delete "$cacheKey" -R $REPO -B $BRANCH --confirm
           done
           echo "Done"
         env:

--- a/.github/workflows/cleanup_cache.yml
+++ b/.github/workflows/cleanup_cache.yml
@@ -24,7 +24,7 @@ jobs:
           ## Setting this to not fail the workflow while deleting cache keys. 
           set +e
           echo "Deleting caches..."
-          for cacheKey in $cacheKeysForPR
+          for cacheKey in "$cacheKeysForPR"
           do
               gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
           done

--- a/.github/workflows/cleanup_cache.yml
+++ b/.github/workflows/cleanup_cache.yml
@@ -15,11 +15,11 @@ jobs:
         run: |
           gh extension install actions/gh-actions-cache
           
-          REPO=${{ github.repository }}
+          REPO="${{ github.repository }}"
           BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
 
           echo "Fetching list of cache key"
-          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
+          cacheKeysForPR="$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )"
 
           ## Setting this to not fail the workflow while deleting cache keys. 
           set +e

--- a/.github/workflows/cleanup_cache.yml
+++ b/.github/workflows/cleanup_cache.yml
@@ -15,18 +15,18 @@ jobs:
         run: |
           gh extension install actions/gh-actions-cache
           
-          REPO="${{ github.repository }}"
-          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+          REPO=${{ github.repository }}
+          BRANCH=refs/pull/${{ github.event.pull_request.number }}/merge"
 
           echo "Fetching list of cache key"
-          cacheKeysForPR="$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )"
+          cacheKeysForPR="$(gh actions-cache list -R "$REPO" -B "$BRANCH" | cut -f 1 )"
 
           ## Setting this to not fail the workflow while deleting cache keys. 
           set +e
           echo "Deleting caches..."
-          for cacheKey in "$cacheKeysForPR"
+          for cacheKey in $cacheKeysForPR
           do
-              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+              gh actions-cache delete "$cacheKey" -R $REPO -B "$BRANCH" --confirm
           done
           echo "Done"
         env:


### PR DESCRIPTION
This PR adds a GitHub workflow to clean the cache from each PR automatically after closing it.

Since we use caches in different workflows it's a good practice to delete the unwanted ones as soon as the don't needed anymore