### PR TITLE
Allow Release Action To Start Manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: release
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
This adds the option to start the release pipeline manually, since it stills under development