### PR TITLE
Added:  Add package name to CHANGELOG assembly workflow

### DIFF
--- a/.github/workflows/changelog-assembly.yml
+++ b/.github/workflows/changelog-assembly.yml
@@ -35,6 +35,7 @@ jobs:
           aeruginous increment-version \
             -v "$(cat .version)" \
             -r ${{ inputs.release }} \
+            -p tui-journal \
             -e .version \
             -e CITATION.cff \
             -e Cargo.lock \


### PR DESCRIPTION
This PR adds the package name to the CHANGELOG assembly workflow in order satisfy the requirements of Aeruginous v3.0.0 for the update of Cargo.lock files; see https://github.com/kevinmatthes/aeruginous-rs/discussions/430.