### PR TITLE
Fixed:  Prevent release generation in forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   create-release:
+    if: github.repository == 'AmmarAbouZor/tui-journal'
     name: create-release
     runs-on: ubuntu-latest
     outputs:
@@ -31,6 +32,7 @@ jobs:
           tag_name: v${{ steps.tag_name.outputs.version }}
 
   build-release:
+    if: github.repository == 'AmmarAbouZor/tui-journal'
     name: build-release
     needs: ['create-release']
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
When I just updated my fork, the release workflow created me a release.  The workflow should only work in the original repository, so I fixed this.