### PR TITLE
Changed:  Call Docker images of linters directly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: devops-actions/actionlint@v0.1.1
+      - uses: docker://rhysd/actionlint:latest
+        with:
+          args: -color
 
   build:
 
@@ -51,6 +53,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - uses: citation-file-format/cffconvert-github-action@2.0.0
+
+      - uses: docker://citationcff/cffconvert:latest
         with:
           args: --validate


### PR DESCRIPTION
This PR reduces the maintenance effort of the main CI definition.

The main CI calls two Actions which are technically just wrappers around Docker images.  By calling them directly instead of binding the wrappers, we do not only save some time, we are furthermore allowed to just call the very latest image available such that we do not need to care about updates for these images anymore.

If you prefer to install updates for the Docker images by merging PRs, we can discuss the required setup and I will adjust the workflow accordingly, then.