### PR TITLE
Fixed: Fix Release action using MakeFile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,35 @@ permissions:
   contents: write
 
 jobs:
+
+  build-release:
+    if: github.repository == 'AmmarAbouZor/tui-journal'
+    name: build-release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-2022]
+
+    steps:
+    - uses: actions/checkout@v3.5.3
+
+    - name: Setup MUSL
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        rustup target add x86_64-unknown-linux-musl
+        sudo apt-get -qq install musl-tools
+
+    - name: Build Release Mac
+      if: matrix.os == 'macos-latest'
+      run: make release-mac
+    - name: Build Release Linux
+      if: matrix.os == 'ubuntu-latest'
+      run: make release-linux-musl
+    - name: Build Release Win
+      if: matrix.os == 'windows-latest'
+      run: make release-win
+
   create-release:
     if: github.repository == 'AmmarAbouZor/tui-journal'
     name: create-release
@@ -30,52 +59,10 @@ jobs:
         with:
           generate_release_notes: true
           tag_name: v${{ steps.tag_name.outputs.version }}
+          files: |
+            ./release/*.tar.gz
+            ./release/*.zip
+            ./release/*.msi
 
-  build-release:
-    if: github.repository == 'AmmarAbouZor/tui-journal'
-    name: build-release
-    needs: ['create-release']
-    runs-on: ${{ matrix.os }}
-    env:
-      CARGO: cargo
-      TARGET_DIR: ./target
-      RUST_BACKTRACE: 1
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-2022]
-        target:
-          - x86_64-unknown-linux-musl
-          - aarch64-unknown-linux-gnu
-          - x86_64-apple-darwin
-          - x86_64-pc-windows-msvc
-
-    steps:
-      - uses: actions/checkout@v3.5.3
-
-      - name: Build binaries
-        run: ${{ env.CARGO }} build --verbose --release --target ${{ matrix.target }}
-
-      - name: Build archive
-        run: |
-          staging="tjournal-${{ needs.create-release.outputs.app_version }}-${{ matrix.target }}"
-          mkdir -p "$staging"
-          if [ "${{ matrix.os }}" = "windows-2022" ]; then
-            cp "target/${{ matrix.target }}/release/tjournal.exe" "$staging/"
-            7z a -tzip "$staging.zip" "$staging"
-            echo "ASSET=$staging.zip" >> "$GITHUB_ENV"
-          else
-            cp "target/${{ matrix.target }}/release/tjournal" "$staging/"
-            tar czf "$staging.tar.gz" "$staging"
-            echo "ASSET=$staging.tar.gz" >> "$GITHUB_ENV"
-          fi
-
-      - name: Upload release archive
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ${{ env.ASSET }}
-          asset_name: ${{ env.ASSET }}
-          asset_content_type: application/octet-stream

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+.PHONY: build-release 
+
+cargo_check:
+	cargo check
+	cargo check --no-default-features -F json
+	cargo check --no-default-features -F sqlite
+
+run_test:
+	cargo test
+
+clippy:
+	cargo clippy
+
+build-release:
+	cargo build --release
+
+release-mac: build-release
+	strip target/release/tjournal
+	otool -L target/release/tjournal
+	mkdir -p release
+	tar -C ./target/release/ -czvf ./release/tjournal-mac.tar.gz ./tjournal
+	ls -lisah ./release/tjournal-mac.tar.gz
+
+release-win: build-release
+	mkdir -p release
+	tar -C ./target/release/ -czvf ./release/tjournal-win.tar.gz ./tjournal.exe
+	cargo install cargo-wix --version 0.3.3
+	cargo wix -p tjournal --no-build --nocapture --output ./release/tjournal.msi
+	ls -l ./release/tjournal.msi 
+
+release-linux-musl: 
+	cargo build --release --target=x86_64-unknown-linux-musl
+	strip target/x86_64-unknown-linux-musl/release/tjournal
+	mkdir -p release
+	tar -C ./target/x86_64-unknown-linux-musl/release/ -czvf ./release/tjournal-linux-musl.tar.gz ./tjournal
+
+install:
+	cargo install --path "." 
+
+install_sqlite:
+	cargo install --path "." --no-default-features -F sqlite 
+
+install_json:
+	cargo install --path "." --no-default-features -F json 
+


### PR DESCRIPTION
This PR closes #84 

- It adds a MakeFile to:
1. Create the binaries for the release on different Environments
1. Run Useful commands locally to check or install with different features sets

- It add the following fixes to the Release Action:
1. Uses MakeFile to create the release's binaries
2. Install missing tools for Linux musl environment 
3. Add the binaries to the release from the release action directly