### PR TITLE
Added: Fuzzy Finder for Journals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,6 +660,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1971,6 +1980,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2158,6 +2177,7 @@ dependencies = [
  "crossterm",
  "directories",
  "futures-util",
+ "fuzzy-matcher",
  "git2",
  "log",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ tui-textarea = "0.2"
 scopeguard = "1.1.0"
 git2 = { version = "0.17.2", default-features = false }
 rayon = "1.7.0"
+fuzzy-matcher = "0.3.7"
 # Textarea crate supports ratatui but it doesn't provide a new version on crates.io to support it
 # crossterm = "0.26"
 # tui = { version = "0.20", package = "ratatui" }

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ TUI-Journal is a terminal-based application written in Rust that allows you to w
 - Create, edit, and delete entries easily.
 - Edit journal content with the built-in editor or use your favourite terminal text editor from withing the app.
 - Add custom tags to the journals and use them in the built-in filter.
+- Fuzzy Finder: Locate your desired journal with lightning-fast speed.
 - Search functions for journals title and content in the built-in filter.
 - Control many journals at once via the multi-select mode
 - Keybindings is a combination of VIM and Emacs motions (VIM for navigation and Emacs for editing texts in edit-mode).

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -197,6 +197,10 @@ pub fn get_entries_list_keymaps() -> Vec<Keymap> {
             Input::new(KeyCode::Char('x'), KeyModifiers::NONE),
             UICommand::ResetFilter,
         ),
+        Keymap::new(
+            Input::new(KeyCode::Char('u'), KeyModifiers::NONE),
+            UICommand::ShowFuzzyFind,
+        ),
     ]
 }
 

--- a/src/app/ui/commands/entries_list_cmd.rs
+++ b/src/app/ui/commands/entries_list_cmd.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{collections::HashMap, env};
 
 use crate::app::{external_editor, ui::*, App, UIComponents};
 
@@ -396,8 +396,13 @@ pub fn exec_show_fuzzy_find<D: DataProvider>(
 
 #[inline]
 fn show_fuzzy_find<D: DataProvider>(ui_components: &mut UIComponents, app: &mut App<D>) {
-    //TODO:
-    todo!()
+    let entries: HashMap<u32, String> = app
+        .get_active_entries()
+        .map(|entry| (entry.id, entry.title.to_owned()))
+        .collect();
+    ui_components
+        .popup_stack
+        .push(Popup::FuzzFind(Box::new(FuzzFindPopup::new(entries))));
 }
 
 pub async fn continue_fuzzy_find<'a, D: DataProvider>(

--- a/src/app/ui/commands/entries_list_cmd.rs
+++ b/src/app/ui/commands/entries_list_cmd.rs
@@ -380,3 +380,42 @@ pub fn exec_reset_filter<D: DataProvider>(app: &mut App<D>) -> CmdResult {
 
     Ok(HandleInputReturnType::Handled)
 }
+
+pub fn exec_show_fuzzy_find<D: DataProvider>(
+    ui_components: &mut UIComponents,
+    app: &mut App<D>,
+) -> CmdResult {
+    if ui_components.has_unsaved() {
+        ui_components.show_unsaved_msg_box(Some(UICommand::ShowFuzzyFind));
+    } else {
+        show_fuzzy_find(ui_components, app);
+    }
+
+    Ok(HandleInputReturnType::Handled)
+}
+
+#[inline]
+fn show_fuzzy_find<D: DataProvider>(ui_components: &mut UIComponents, app: &mut App<D>) {
+    //TODO:
+    todo!()
+}
+
+pub async fn continue_fuzzy_find<'a, D: DataProvider>(
+    ui_components: &mut UIComponents<'a>,
+    app: &mut App<D>,
+    msg_box_result: MsgBoxResult,
+) -> CmdResult {
+    match msg_box_result {
+        MsgBoxResult::Ok | MsgBoxResult::Cancel => {}
+        MsgBoxResult::Yes => {
+            exec_save_entry_content(ui_components, app).await?;
+            show_fuzzy_find(ui_components, app);
+        }
+        MsgBoxResult::No => {
+            discard_current_content(ui_components, app);
+            show_fuzzy_find(ui_components, app);
+        }
+    }
+
+    Ok(HandleInputReturnType::Handled)
+}

--- a/src/app/ui/commands/mod.rs
+++ b/src/app/ui/commands/mod.rs
@@ -44,6 +44,7 @@ pub enum UICommand {
     MulSelExportEntries,
     ShowFilter,
     ResetFilter,
+    ShowFuzzyFind,
 }
 
 #[derive(Debug, Clone)]
@@ -152,6 +153,10 @@ impl UICommand {
                 "Reset filter",
                 "Reset the applied filter on journals",
             ),
+            UICommand::ShowFuzzyFind => CommandInfo::new(
+                "Fuzzy find",
+                "Open fuzzy find popup for journals",
+            ),
         }
     }
 
@@ -189,6 +194,7 @@ impl UICommand {
             UICommand::MulSelExportEntries => exec_export_selected_entries(ui_components, app),
             UICommand::ShowFilter => exec_show_filter(ui_components, app),
             UICommand::ResetFilter => exec_reset_filter(app),
+            UICommand::ShowFuzzyFind => exec_show_fuzzy_find(ui_components, app),
         }
     }
 
@@ -246,6 +252,9 @@ impl UICommand {
             UICommand::MulSelExportEntries => not_implemented(),
             UICommand::ShowFilter => continue_show_filter(ui_components, app, msg_box_result).await,
             UICommand::ResetFilter => not_implemented(),
+            UICommand::ShowFuzzyFind => {
+                continue_fuzzy_find(ui_components, app, msg_box_result).await
+            }
         }
     }
 }

--- a/src/app/ui/fuzz_find/mod.rs
+++ b/src/app/ui/fuzz_find/mod.rs
@@ -243,7 +243,6 @@ impl<'a> FuzzFindPopup<'a> {
             self.list_state.select(None);
         } else {
             // Select first item when search query is updated
-            // TODO: Check if it better to not select anything at first
             self.list_state.select(Some(0));
         }
     }

--- a/src/app/ui/fuzz_find/mod.rs
+++ b/src/app/ui/fuzz_find/mod.rs
@@ -1,13 +1,18 @@
 use std::collections::HashMap;
 
-use tui::{backend::Backend, layout::Rect, Frame};
+use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
+use tui::{backend::Backend, layout::Rect, widgets::ListState, Frame};
 use tui_textarea::TextArea;
 
 use crate::app::keymap::Input;
 
 pub struct FuzzFindPopup<'a> {
-    text_box: TextArea<'a>,
+    query_text_box: TextArea<'a>,
     entries: HashMap<u32, String>,
+    search_query: Option<String>,
+    filtered_entries: Vec<FilteredEntry>,
+    list_state: ListState,
+    matcher: SkimMatcherV2,
 }
 
 pub enum FuzzFindReturn {
@@ -16,10 +21,29 @@ pub enum FuzzFindReturn {
     SelectEntry(Option<u32>),
 }
 
+struct FilteredEntry {
+    id: u32,
+    score: i64,
+    indices: Vec<usize>,
+}
+
+impl FilteredEntry {
+    fn new(id: u32, score: i64, indices: Vec<usize>) -> Self {
+        Self { id, score, indices }
+    }
+}
+
 impl<'a> FuzzFindPopup<'a> {
     pub fn new(entries: HashMap<u32, String>) -> Self {
-        let text_box = TextArea::default();
-        Self { text_box, entries }
+        let query_text_box = TextArea::default();
+        Self {
+            query_text_box,
+            entries,
+            search_query: None,
+            filtered_entries: Vec::new(),
+            list_state: ListState::default(),
+            matcher: SkimMatcherV2::default(),
+        }
     }
 
     pub fn render_widget<B: Backend>(&mut self, frame: &mut Frame<B>, area: Rect) {
@@ -30,5 +54,43 @@ impl<'a> FuzzFindPopup<'a> {
     pub fn handle_input(&mut self, input: &Input) -> FuzzFindReturn {
         //TODO:
         todo!()
+    }
+
+    fn update_search_query(&mut self) {
+        self.filtered_entries.clear();
+
+        let query_text = self
+            .query_text_box
+            .lines()
+            .first()
+            .expect("Query text box has one line");
+
+        self.search_query = if query_text.is_empty() {
+            None
+        } else {
+            Some(query_text.to_owned())
+        };
+
+        if let Some(query) = self.search_query.as_ref() {
+            self.filtered_entries = self
+                .entries
+                .iter()
+                .filter_map(|entry| {
+                    self.matcher
+                        .fuzzy_indices(entry.1, query)
+                        .map(|(score, indices)| FilteredEntry::new(*entry.0, score, indices))
+                })
+                .collect();
+
+            self.filtered_entries.sort_by(|a, b| b.score.cmp(&a.score));
+        }
+
+        if self.filtered_entries.is_empty() {
+            self.list_state.select(None);
+        } else {
+            // Select first item when search query is updated
+            // TODO: Check if it better to not select anything at first
+            self.list_state.select(Some(0));
+        }
     }
 }

--- a/src/app/ui/fuzz_find/mod.rs
+++ b/src/app/ui/fuzz_find/mod.rs
@@ -5,7 +5,8 @@ use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 use tui::{
     backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Style},
+    style::{Color, Modifier, Style},
+    text::{Span, Spans},
     widgets::{Block, BorderType, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
     Frame,
 };
@@ -108,7 +109,24 @@ impl<'a> FuzzFindPopup<'a> {
                     .get(&entry.id)
                     .expect("Entry must be in entries map");
 
-                ListItem::new(entry_title.to_owned())
+                let spans: Vec<_> = entry_title
+                    .chars()
+                    .enumerate()
+                    .map(|(idx, ch)| {
+                        Span::styled(
+                            ch.to_string(),
+                            if entry.indices.contains(&idx) {
+                                Style::default()
+                                    .add_modifier(Modifier::BOLD)
+                                    .fg(Color::LightBlue)
+                            } else {
+                                Style::default()
+                            },
+                        )
+                    })
+                    .collect();
+
+                ListItem::new(Spans::from(spans))
             })
             .collect();
 

--- a/src/app/ui/fuzz_find/mod.rs
+++ b/src/app/ui/fuzz_find/mod.rs
@@ -1,0 +1,34 @@
+use std::collections::HashMap;
+
+use tui::{backend::Backend, layout::Rect, Frame};
+use tui_textarea::TextArea;
+
+use crate::app::keymap::Input;
+
+pub struct FuzzFindPopup<'a> {
+    text_box: TextArea<'a>,
+    entries: HashMap<u32, String>,
+}
+
+pub enum FuzzFindReturn {
+    KeepPopup,
+    Close,
+    SelectEntry(Option<u32>),
+}
+
+impl<'a> FuzzFindPopup<'a> {
+    pub fn new(entries: HashMap<u32, String>) -> Self {
+        let text_box = TextArea::default();
+        Self { text_box, entries }
+    }
+
+    pub fn render_widget<B: Backend>(&mut self, frame: &mut Frame<B>, area: Rect) {
+        //TODO:
+        todo!()
+    }
+
+    pub fn handle_input(&mut self, input: &Input) -> FuzzFindReturn {
+        //TODO:
+        todo!()
+    }
+}

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -9,6 +9,7 @@ use self::{
     export_popup::ExportPopup,
     filter_popup::FilterPopup,
     footer::render_footer,
+    fuzz_find::FuzzFindPopup,
     help_popup::{HelpInputInputReturn, HelpPopup},
     msg_box::{MsgBox, MsgBoxActions, MsgBoxType},
 };
@@ -37,6 +38,7 @@ mod entry_popup;
 mod export_popup;
 mod filter_popup;
 mod footer;
+mod fuzz_find;
 mod help_popup;
 mod msg_box;
 pub mod ui_functions;
@@ -61,6 +63,7 @@ pub enum Popup<'a> {
     MsgBox(Box<MsgBox>),
     Export(Box<ExportPopup<'a>>),
     Filter(Box<FilterPopup<'a>>),
+    FuzzFind(Box<FuzzFindPopup<'a>>),
 }
 
 pub struct UIComponents<'a> {
@@ -149,6 +152,7 @@ impl<'a, 'b> UIComponents<'a> {
                 Popup::MsgBox(msg_box) => msg_box.render_widget(f, f.size()),
                 Popup::Export(export_popup) => export_popup.render_widget(f, f.size()),
                 Popup::Filter(filter_popup) => filter_popup.render_widget(f, f.size()),
+                Popup::FuzzFind(fuzz_find) => fuzz_find.render_widget(f, f.size()),
             }
         }
     }
@@ -267,6 +271,15 @@ impl<'a, 'b> UIComponents<'a> {
                             let entry_id = app.get_active_entries().next().map(|entrie| entrie.id);
                             self.set_current_entry(entry_id, app);
                         }
+                    }
+                },
+                Popup::FuzzFind(fuzz_find) => match fuzz_find.handle_input(input) {
+                    fuzz_find::FuzzFindReturn::KeepPopup => {}
+                    fuzz_find::FuzzFindReturn::Close => {
+                        self.popup_stack.pop().expect("popup stack isn't empty");
+                    }
+                    fuzz_find::FuzzFindReturn::SelectEntry(entry_id) => {
+                        self.set_current_entry(entry_id, app);
                     }
                 },
             }

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -274,12 +274,13 @@ impl<'a, 'b> UIComponents<'a> {
                     }
                 },
                 Popup::FuzzFind(fuzz_find) => match fuzz_find.handle_input(input) {
-                    fuzz_find::FuzzFindReturn::KeepPopup => {}
                     fuzz_find::FuzzFindReturn::Close => {
                         self.popup_stack.pop().expect("popup stack isn't empty");
                     }
                     fuzz_find::FuzzFindReturn::SelectEntry(entry_id) => {
-                        self.set_current_entry(entry_id, app);
+                        if entry_id.is_some() {
+                            self.set_current_entry(entry_id, app);
+                        }
                     }
                 },
             }


### PR DESCRIPTION
This PR closes #99 

It adds fuzzy finder for the journals using the keymap `u` (I'm still not sure if there is a better keybinding for it).

The selected journal in the main view will stay in sync with the selected one in the fuzzy finder popup