### PR TITLE
Fix: Release GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
   create-release:
     if: github.repository == 'AmmarAbouZor/tui-journal'
     name: create-release
+    needs: ['build-release']
     runs-on: ubuntu-latest
     outputs:
       upload_url: ${{ steps.release.outputs.upload_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         rustup target add x86_64-unknown-linux-musl
-        sudo apt-get -qq install musl-tools
+        sudo apt-get -qq install musl-tools libssl-dev
 
     - name: Build Release Mac
       if: matrix.os == 'macos-latest'


### PR DESCRIPTION
This PR Adds the following fixes for the Release GitHub Action

- It installs Open SSL dependencies for LINUX MUSL
- Make Creating the release depend on creating the binaries to include them in the release. 