### PR TITLE
Fix: Fix SQLite connection string path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,6 +1220,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
+name = "path-absolutize"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43eb3595c63a214e1b37b44f44b0a84900ef7ae0b4c5efce59e123d246d7a0de"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d55e486337acb9973cdea3ec5638c1b3bcb22e573b2b7b41969e0c744d5a15e"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2180,6 +2198,7 @@ dependencies = [
  "fuzzy-matcher",
  "git2",
  "log",
+ "path-absolutize",
  "rayon",
  "scopeguard",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ scopeguard = "1.2.0"
 git2 = { version = "0.17.2", default-features = false }
 rayon = "1.7.0"
 fuzzy-matcher = "0.3.7"
+path-absolutize = "3.1.0"
 # Textarea crate supports ratatui but it doesn't provide a new version on crates.io to support it
 # crossterm = "0.26"
 # tui = { version = "0.20", package = "ratatui" }

--- a/backend/src/sqlite/mod.rs
+++ b/backend/src/sqlite/mod.rs
@@ -4,6 +4,7 @@ use self::sqlite_helper::EntryIntermediate;
 
 use super::*;
 use anyhow::anyhow;
+use path_absolutize::Absolutize;
 use sqlx::{
     migrate::MigrateDatabase,
     sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous},
@@ -18,23 +19,12 @@ pub struct SqliteDataProvide {
 
 impl SqliteDataProvide {
     pub async fn from_file(file_path: PathBuf) -> anyhow::Result<Self> {
-        let file_full_path = if file_path.exists() {
-            if file_path.is_absolute() {
-                file_path
-            } else {
-                tokio::fs::canonicalize(file_path).await?
+        let file_full_path = file_path.absolutize()?;
+        if !file_path.exists() {
+            if let Some(parent) = file_path.parent() {
+                tokio::fs::create_dir_all(parent).await?;
             }
-        } else if let Some(parent) = file_path.parent() {
-            tokio::fs::create_dir_all(parent).await?;
-            if file_path.is_absolute() {
-                file_path
-            } else {
-                let parent_full_path = tokio::fs::canonicalize(parent).await?;
-                parent_full_path.join(file_path.file_name().unwrap())
-            }
-        } else {
-            file_path
-        };
+        }
 
         let db_url = format!("sqlite://{}", file_full_path.to_string_lossy());
 

--- a/backend/src/sqlite/mod.rs
+++ b/backend/src/sqlite/mod.rs
@@ -28,7 +28,7 @@ impl SqliteDataProvide {
             file_path
         };
 
-        let db_url = format!("sqlite://{}", file_full_path.to_string_lossy());
+        let db_url = format!("sqlite:{}", file_full_path.to_string_lossy());
 
         SqliteDataProvide::create(&db_url).await
     }

--- a/backend/src/sqlite/mod.rs
+++ b/backend/src/sqlite/mod.rs
@@ -19,16 +19,24 @@ pub struct SqliteDataProvide {
 impl SqliteDataProvide {
     pub async fn from_file(file_path: PathBuf) -> anyhow::Result<Self> {
         let file_full_path = if file_path.exists() {
-            tokio::fs::canonicalize(file_path).await?
+            if file_path.is_absolute() {
+                file_path
+            } else {
+                tokio::fs::canonicalize(file_path).await?
+            }
         } else if let Some(parent) = file_path.parent() {
             tokio::fs::create_dir_all(parent).await?;
-            let parent_full_path = tokio::fs::canonicalize(parent).await?;
-            parent_full_path.join(file_path.file_name().unwrap())
+            if file_path.is_absolute() {
+                file_path
+            } else {
+                let parent_full_path = tokio::fs::canonicalize(parent).await?;
+                parent_full_path.join(file_path.file_name().unwrap())
+            }
         } else {
             file_path
         };
 
-        let db_url = format!("sqlite:{}", file_full_path.to_string_lossy());
+        let db_url = format!("sqlite://{}", file_full_path.to_string_lossy());
 
         SqliteDataProvide::create(&db_url).await
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -12,6 +12,7 @@ use crate::{
 pub mod commands;
 pub use commands::CliCommand;
 pub use commands::PendingCliCommand;
+use path_absolutize::Absolutize;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
@@ -88,7 +89,7 @@ impl Cli {
 async fn set_json_path(path: PathBuf, settings: &mut Settings) -> anyhow::Result<()> {
     ensure_path_exists(&path).await?;
 
-    settings.json_backend.file_path = Some(fs::canonicalize(path)?);
+    settings.json_backend.file_path = path.absolutize().map(PathBuf::from).ok();
 
     Ok(())
 }
@@ -102,7 +103,6 @@ async fn ensure_path_exists(path: &Path) -> anyhow::Result<()> {
         fs::create_dir_all(parent)?;
     }
 
-    fs::File::create(path)?;
     Ok(())
 }
 
@@ -110,7 +110,7 @@ async fn ensure_path_exists(path: &Path) -> anyhow::Result<()> {
 async fn set_sqlite_path(path: PathBuf, settings: &mut Settings) -> anyhow::Result<()> {
     ensure_path_exists(&path).await?;
 
-    settings.sqlite_backend.file_path = Some(fs::canonicalize(path)?);
+    settings.sqlite_backend.file_path = path.absolutize().map(PathBuf::from).ok();
 
     Ok(())
 }


### PR DESCRIPTION
This PR closes #131 

Previous SQLite connection string didn't work on windows machine, because it always add a backslash to the start of the query.

The current change should make the path works on all operating systems. But I still needs to be tested