### PR TITLE
Migrate to Ratatui & Update Crossterm to 27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,11 +392,11 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "crossterm_winapi",
  "futures-core",
  "libc",
@@ -824,6 +824,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,6 +854,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -1341,6 +1356,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e2e4cd95294a85c3b4446e63ef054eea43e0205b1fd60120c16b74ff7ff96ad"
+dependencies = [
+ "bitflags 2.3.3",
+ "cassowary",
+ "crossterm",
+ "indoc",
+ "itertools 0.11.0",
+ "paste",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "rayon"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,6 +1480,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
@@ -1556,9 +1595,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -1667,7 +1706,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c12bc9199d1db8234678b7051747c07f517cdcf019262d1847b94ec8b1aee3e"
 dependencies = [
- "itertools",
+ "itertools 0.10.5",
  "nom",
  "unicode_categories",
 ]
@@ -1887,6 +1926,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.28",
+]
 
 [[package]]
 name = "subtle"
@@ -2133,19 +2194,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tui"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
-dependencies = [
- "bitflags 1.3.2",
- "cassowary",
- "crossterm",
- "unicode-segmentation",
- "unicode-width",
-]
-
-[[package]]
 name = "tui-journal"
 version = "0.3.1"
 dependencies = [
@@ -2160,6 +2208,7 @@ dependencies = [
  "git2",
  "log",
  "path-absolutize",
+ "ratatui",
  "rayon",
  "scopeguard",
  "serde",
@@ -2170,18 +2219,17 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
- "tui",
  "tui-textarea",
 ]
 
 [[package]]
 name = "tui-textarea"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437ad97a57d66f7231dab16f51ede1ff5a3aac68c83eb10fa3a178e454b63cae"
+checksum = "8ddd5d2aea3541baccf9c298ecace702201e0fbf348e80bd8811acb4f62b5952"
 dependencies = [
  "crossterm",
- "tui",
+ "ratatui",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4.20"
 chrono = { version = "0.4.31", features = ["serde"] }
 async-trait = "0.1.73"
 clap = { version = "4.4.5", features = ["derive"] }
-crossterm = {version =  "0.25", features = ["event-stream"]}
+crossterm = {version =  "0.27.0", features = ["event-stream"]}
 directories = "5.0.0"
 simplelog = "0.12.1"
 textwrap = "0.16.0"
@@ -29,18 +29,13 @@ toml = "0.8.0"
 sqlx = {version = "0.7.1", features = ["runtime-tokio-native-tls", "sqlite", "chrono"], optional = true}
 futures-util = { version = "0.3", default-features = false }
 
-# TODO: follow issue link: https://github.com/rhysd/tui-textarea/issues/19 and reapplay the migration
-tui = "0.19"
-tui-textarea = "0.2"
 scopeguard = "1.2.0"
 git2 = { version = "0.18.1", default-features = false }
 rayon = "1.8.0"
 fuzzy-matcher = "0.3.7"
 path-absolutize = "3.1.1"
-# Textarea crate supports ratatui but it doesn't provide a new version on crates.io to support it
-# crossterm = "0.26"
-# tui = { version = "0.20", package = "ratatui" }
-# tui-textarea = { git = "https://github.com/rhysd/tui-textarea", version = "0.2", features = ["ratatui-crossterm"], default-features=false}
+tui-textarea = { version = "0.2.2", features = ["ratatui-crossterm"], default-features=false}
+ratatui = { version = "0.23.0", features = ["all-widgets"]}
 
 [features]
 default = ["json", "sqlite"]

--- a/src/app/runner.rs
+++ b/src/app/runner.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use crossterm::event::{Event, EventStream};
-use tui::{backend::Backend, Terminal};
+use ratatui::{backend::Backend, Terminal};
 
 use crate::app::{App, UIComponents};
 use crate::cli::PendingCliCommand;

--- a/src/app/ui/editor/mod.rs
+++ b/src/app/ui/editor/mod.rs
@@ -1,5 +1,5 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
-use tui::{
+use ratatui::{
     backend::Backend,
     layout::Rect,
     style::{Color, Modifier, Style},

--- a/src/app/ui/entries_list/mod.rs
+++ b/src/app/ui/entries_list/mod.rs
@@ -1,11 +1,13 @@
 use chrono::Datelike;
 
-use tui::backend::Backend;
-use tui::layout::{Alignment, Rect};
-use tui::style::{Color, Modifier, Style};
-use tui::text::{Span, Spans};
-use tui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap};
-use tui::Frame;
+use ratatui::{
+    backend::Backend,
+    layout::{Alignment, Rect},
+    style::{Color, Modifier, Style},
+    text::{Span, Spans},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
+    Frame,
+};
 
 use backend::DataProvider;
 

--- a/src/app/ui/entries_list/mod.rs
+++ b/src/app/ui/entries_list/mod.rs
@@ -4,7 +4,7 @@ use ratatui::{
     backend::Backend,
     layout::{Alignment, Rect},
     style::{Color, Modifier, Style},
-    text::{Span, Spans},
+    text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
     Frame,
 };
@@ -69,17 +69,17 @@ impl<'a> EntriesList {
                     foreground_color
                 };
 
-                let mut spans: Vec<Spans> = title_lines
+                let mut spans: Vec<Line> = title_lines
                     .iter()
                     .map(|line| {
-                        Spans::from(Span::styled(
+                        Line::from(Span::styled(
                             line.to_string(),
                             Style::default().fg(fg_color).add_modifier(Modifier::BOLD),
                         ))
                     })
                     .collect();
 
-                spans.push(Spans::from(Span::styled(
+                spans.push(Line::from(Span::styled(
                     format!(
                         "{},{},{}",
                         entry.date.day(),
@@ -102,7 +102,7 @@ impl<'a> EntriesList {
                     tag_line
                         .into_iter()
                         .map(|line| {
-                            Spans::from(Span::styled(
+                            Line::from(Span::styled(
                                 line.to_string(),
                                 Style::default()
                                     .fg(Color::LightCyan)

--- a/src/app/ui/entry_popup/mod.rs
+++ b/src/app/ui/entry_popup/mod.rs
@@ -1,7 +1,7 @@
 use anyhow::Ok;
 use chrono::{Datelike, Local, NaiveDate, TimeZone, Utc};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use tui::{
+use ratatui::{
     backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Style},

--- a/src/app/ui/entry_popup/tags.rs
+++ b/src/app/ui/entry_popup/tags.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use crossterm::event::{KeyCode, KeyModifiers};
-use tui::{
+use ratatui::{
     backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},

--- a/src/app/ui/export_popup/mod.rs
+++ b/src/app/ui/export_popup/mod.rs
@@ -2,7 +2,7 @@ use std::{env, path::PathBuf};
 
 use backend::{DataProvider, Entry};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use tui::{
+use ratatui::{
     backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::Style,

--- a/src/app/ui/filter_popup/mod.rs
+++ b/src/app/ui/filter_popup/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use tui::{
+use ratatui::{
     backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},

--- a/src/app/ui/footer.rs
+++ b/src/app/ui/footer.rs
@@ -1,5 +1,5 @@
 use backend::DataProvider;
-use tui::{
+use ratatui::{
     backend::Backend,
     layout::{Alignment, Rect},
     style::Style,

--- a/src/app/ui/fuzz_find/mod.rs
+++ b/src/app/ui/fuzz_find/mod.rs
@@ -6,7 +6,7 @@ use ratatui::{
     backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
-    text::{Span, Spans},
+    text::{Line, Span},
     widgets::{Block, BorderType, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
     Frame,
 };
@@ -126,7 +126,7 @@ impl<'a> FuzzFindPopup<'a> {
                     })
                     .collect();
 
-                ListItem::new(Spans::from(spans))
+                ListItem::new(Line::from(spans))
             })
             .collect();
 

--- a/src/app/ui/fuzz_find/mod.rs
+++ b/src/app/ui/fuzz_find/mod.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, usize};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
-use tui::{
+use ratatui::{
     backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},

--- a/src/app/ui/help_popup/global_bindings.rs
+++ b/src/app/ui/help_popup/global_bindings.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use tui::widgets::TableState;
+use ratatui::widgets::TableState;
 
 use crate::app::{
     keymap::{

--- a/src/app/ui/help_popup/keybindings_table.rs
+++ b/src/app/ui/help_popup/keybindings_table.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use tui::widgets::TableState;
+use ratatui::widgets::TableState;
 
 use crate::app::{keymap::Input, ui::UICommand};
 

--- a/src/app/ui/help_popup/mod.rs
+++ b/src/app/ui/help_popup/mod.rs
@@ -3,7 +3,7 @@ use ratatui::{
     backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
-    text::{Span, Spans},
+    text::{Line, Span},
     widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, Tabs, Wrap},
     Frame,
 };
@@ -48,15 +48,15 @@ impl KeybindingsTabs {
         }
     }
 
-    fn get_headers<'a>() -> Vec<Spans<'a>> {
+    fn get_headers<'a>() -> Vec<Line<'a>> {
         let highlight_style = Style::default()
             .fg(TAB_LETTER_HIGHLIGHT_COLOR)
             .add_modifier(Modifier::BOLD);
 
         vec![
-            Spans::from(vec![Span::styled("G", highlight_style), Span::raw("lobal")]),
-            Spans::from(vec![Span::styled("E", highlight_style), Span::raw("ditor")]),
-            Spans::from(vec![
+            Line::from(vec![Span::styled("G", highlight_style), Span::raw("lobal")]),
+            Line::from(vec![Span::styled("E", highlight_style), Span::raw("ditor")]),
+            Line::from(vec![
                 Span::styled("M", highlight_style),
                 Span::raw("ulti-Select"),
             ]),

--- a/src/app/ui/help_popup/mod.rs
+++ b/src/app/ui/help_popup/mod.rs
@@ -1,5 +1,5 @@
 use crossterm::event::{KeyCode, KeyModifiers};
-use tui::{
+use ratatui::{
     backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},

--- a/src/app/ui/help_popup/multi_select_bindings.rs
+++ b/src/app/ui/help_popup/multi_select_bindings.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use tui::widgets::TableState;
+use ratatui::widgets::TableState;
 
 use crate::app::{
     keymap::{get_multi_select_keymaps, Input},

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -24,7 +24,7 @@ use super::{
 };
 use anyhow::Result;
 
-use tui::{
+use ratatui::{
     backend::Backend,
     layout::{Constraint, Direction, Layout},
     style::Color,

--- a/src/app/ui/msg_box/mod.rs
+++ b/src/app/ui/msg_box/mod.rs
@@ -1,5 +1,5 @@
 use crossterm::event::KeyCode;
-use tui::{
+use ratatui::{
     backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Style},

--- a/src/app/ui/ui_functions.rs
+++ b/src/app/ui/ui_functions.rs
@@ -1,4 +1,4 @@
-use tui::{
+use ratatui::{
     backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     widgets::{Block, BorderType, Borders, Clear, Paragraph},

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use settings::Settings;
-use tui::{backend::CrosstermBackend, Terminal};
+use ratatui::{backend::CrosstermBackend, Terminal};
 
 mod app;
 mod cli;


### PR DESCRIPTION
This PR migrate from the deprecated [tui-rs](https://crates.io/crates/tui) to its reviving project [Ratatui](https://github.com/ratatui-org/ratatui)

This migration enables Updating Crossterm from 0.25 to 0.27 too
I was able to make this migration after updating [tui-textarea](https://crates.io/crates/tui-textarea) on [crates.io](https://crates.io/)