### PR TITLE
Added: Autosave Option for  External Editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ TUI-Journal is a terminal-based application written in Rust that allows you to w
 - Store your entries in either a plain text file using the JSON format or a SQLite database.
 - Intuitive, responsive and user-friendly text-based user interface (TUI).
 - Create, edit, and delete entries easily.
-- Edit journal content with the built-in editor or use your favourite terminal text editor from withing the app.
+- Edit journal content with the built-in editor or use your favourite terminal text editor from within the app.
 - Add custom tags to the journals and use them in the built-in filter.
 - Fuzzy Finder: Locate your desired journal with lightning-fast speed.
 - Search functions for journals title and content in the built-in filter.
@@ -78,7 +78,7 @@ TUI-Journal is a terminal-based application written in Rust that allows you to w
 - [x]  Database back-end using SQLite.
 - [ ]  RESTful back-end server with a client in the app.
 #### Application:
-- [x]  Edit journals content with external text editor from withing the app.
+- [x]  Edit journals content with external text editor from within the app.
 - [x]  Filter & Search functionalities.
 - [ ]  Customize themes and keybindings.
 - [ ]  Load entries as chunks for better performance.
@@ -199,13 +199,20 @@ Here is a sample of the settings in the `config.toml` file:
 
 ```toml
 backend_type = "Sqlite"   # available options: Json, Sqlite. Default value: Sqlite.
-# Set the external terminal editor to use from withing the app.
-# If the value isn't set the app will try to retrieve the editor from git global configurations then It'll try with the environment varialbes VISUAL, EDITOR then it'll fallback to vi.  
-external_editor = "nvim"
 
 [export]
 default_path = "<Absolute_path_to_export_directory>"   # Optional default path to export multiple journals or a single journal's content. Falls back to the current directory if not specified.
 show_confirmation = true   # Show confirmation after successful export.
+
+[external_editor]
+# Set the external terminal editor to use from within the app.
+# If the value isn't set the app will try to retrieve the editor from git global configurations then It'll try with the environment variables VISUAL, EDITOR then it'll fallback to vi.  
+command = "nvim"
+# Enabling this save the journal content automatically after closing the external editor
+auto_save = false
+
+# Note: external_editor can still be configured in one line to set the command. In that case, the default values for the other fields will be used
+# external_editor = "nvim"
 
 [json_backend]
 file_path = "<Documents-folder>/tui-journal/entries.json"

--- a/src/app/external_editor.rs
+++ b/src/app/external_editor.rs
@@ -22,6 +22,7 @@ pub async fn open_editor(file_path: &Path, settings: &Settings) -> anyhow::Resul
 
     let editor_raw = settings
         .external_editor
+        .command
         .as_ref()
         .cloned()
         .or_else(|| get_git_editor().ok())

--- a/src/app/ui/commands/entries_list_cmd.rs
+++ b/src/app/ui/commands/entries_list_cmd.rs
@@ -308,6 +308,10 @@ pub async fn edit_in_external_editor<'a, D: DataProvider>(
             let new_content = fs::read_to_string(&file_path).await?;
             ui_components.editor.set_entry_content(&new_content, app);
             ui_components.change_active_control(ControlType::EntriesList);
+
+            if app.settings.external_editor.auto_save {
+                exec_save_entry_content(ui_components, app).await?;
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,8 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use settings::Settings;
 use ratatui::{backend::CrosstermBackend, Terminal};
+use settings::Settings;
 
 mod app;
 mod cli;

--- a/src/settings/external_editor.rs
+++ b/src/settings/external_editor.rs
@@ -1,0 +1,25 @@
+use std::{convert::Infallible, str::FromStr};
+
+use serde::{Deserialize, Serialize};
+
+// In older version the external editor was a string only referring to the command.
+// To keep the configuration compatible, deserialize is implemented to accept either string or struct
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct ExternalEditor {
+    #[serde(default)]
+    pub command: Option<String>,
+    #[serde(default)]
+    pub auto_save: bool,
+}
+
+impl FromStr for ExternalEditor {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(ExternalEditor {
+            command: Some(s.into()),
+            ..Default::default()
+        })
+    }
+}

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -1,15 +1,18 @@
-use std::path::PathBuf;
+use std::{convert::Infallible, fmt, marker::PhantomData, path::PathBuf, str::FromStr};
 
-use anyhow::{anyhow, Context, Ok};
+use anyhow::{anyhow, Context};
 use clap::ValueEnum;
 use directories::{BaseDirs, UserDirs};
-use serde::{Deserialize, Serialize};
+use serde::{
+    de::{self, MapAccess, Visitor},
+    Deserialize, Deserializer, Serialize,
+};
 
-use self::export::ExportSettings;
 #[cfg(feature = "json")]
 use self::json_backend::{get_default_json_path, JsonBackend};
 #[cfg(feature = "sqlite")]
 use self::sqlite_backend::{get_default_sqlite_path, SqliteBackend};
+use self::{export::ExportSettings, external_editor::ExternalEditor};
 
 #[cfg(feature = "json")]
 pub mod json_backend;
@@ -17,6 +20,7 @@ pub mod json_backend;
 pub mod sqlite_backend;
 
 mod export;
+mod external_editor;
 
 #[derive(Debug, Deserialize, Serialize, Default)]
 pub struct Settings {
@@ -24,8 +28,8 @@ pub struct Settings {
     pub export: ExportSettings,
     #[serde(default)]
     pub backend_type: Option<BackendType>,
-    #[serde(default)]
-    pub external_editor: Option<String>,
+    #[serde(default, deserialize_with = "string_or_struct")]
+    pub external_editor: ExternalEditor,
     #[cfg(feature = "json")]
     #[serde(default)]
     pub json_backend: JsonBackend,
@@ -126,4 +130,50 @@ fn get_default_data_dir() -> anyhow::Result<PathBuf> {
                 .join("tui-journal")
         })
         .context("Default entries directory path couldn't be retrieved")
+}
+
+/// This function is copied from serde documentations for the use case when the data can be string
+/// or a struct
+fn string_or_struct<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: Deserialize<'de> + FromStr<Err = Infallible>,
+    D: Deserializer<'de>,
+{
+    // This is a Visitor that forwards string types to T's `FromStr` impl and
+    // forwards map types to T's `Deserialize` impl. The `PhantomData` is to
+    // keep the compiler from complaining about T being an unused generic type
+    // parameter. We need T in order to know the Value type for the Visitor
+    // impl.
+    struct StringOrStruct<T>(PhantomData<fn() -> T>);
+
+    impl<'de, T> Visitor<'de> for StringOrStruct<T>
+    where
+        T: Deserialize<'de> + FromStr<Err = Infallible>,
+    {
+        type Value = T;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("string or map")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<T, E>
+        where
+            E: de::Error,
+        {
+            Ok(FromStr::from_str(value).unwrap())
+        }
+
+        fn visit_map<M>(self, map: M) -> Result<T, M::Error>
+        where
+            M: MapAccess<'de>,
+        {
+            // `MapAccessDeserializer` is a wrapper that turns a `MapAccess`
+            // into a `Deserializer`, allowing it to be used as the input to T's
+            // `Deserialize` implementation. T then deserializes itself using
+            // the entries from the map visitor.
+            Deserialize::deserialize(de::value::MapAccessDeserializer::new(map))
+        }
+    }
+
+    deserializer.deserialize_any(StringOrStruct(PhantomData))
 }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -78,11 +78,11 @@ impl Settings {
         self.complete_missing_options()?;
 
         toml::to_string(&self)
-            .map_err(|err| anyhow!("Settings couldn't be srialized\nError info: {}", err))
+            .map_err(|err| anyhow!("Settings couldn't be serialized\nError info: {}", err))
     }
 
     pub fn complete_missing_options(&mut self) -> anyhow::Result<()> {
-        // This check is to ensure that all added fields to settings struct are conisdered here
+        // This check is to ensure that all added fields to settings struct are considered here
         #[cfg(all(debug_assertions, feature = "sqlite", feature = "json"))]
         let Settings {
             backend_type: _,


### PR DESCRIPTION
This PR closes #206 

It adds a new option in the configuration to save the journal content after closing the external editor automatically.

This adds changes to the configurations structure:
 - External-editor changed from a single-line option to a node with two options to configure (command, auto_save)
 - Old configurations will still work. In that case the given string will be interpreted as the command and the other fields will have the default values

Here is an example for the new structure
```toml
[external_editor]
command = "nvim"
auto_save = true
``` 

README has been updated and typos has been fixed