### PR TITLE
Changed: Upgrade Crates Ratatui & Tui-Textarea with breaking changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,6 +969,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "lru"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efa59af2ddfad1854ae27d75009d538d0998b4b2fd47083e743ac1a10e46c60"
+dependencies = [
+ "hashbrown 0.14.0",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1345,6 +1354,24 @@ dependencies = [
  "crossterm",
  "indoc",
  "itertools 0.11.0",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ebc917cfb527a566c37ecb94c7e3fd098353516fb4eb6bea17015ade0182425"
+dependencies = [
+ "bitflags 2.3.3",
+ "cassowary",
+ "crossterm",
+ "indoc",
+ "itertools 0.11.0",
+ "lru",
  "paste",
  "strum",
  "time",
@@ -2187,7 +2214,7 @@ dependencies = [
  "git2",
  "log",
  "path-absolutize",
- "ratatui",
+ "ratatui 0.24.0",
  "rayon",
  "scopeguard",
  "serde",
@@ -2208,7 +2235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8aa3edc9087c29f51e753c6eebb7740e3140a519feb08f89443e5fd16a69b91"
 dependencies = [
  "crossterm",
- "ratatui",
+ "ratatui 0.23.0",
  "unicode-width",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2203,12 +2203,13 @@ dependencies = [
 
 [[package]]
 name = "tui-textarea"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddd5d2aea3541baccf9c298ecace702201e0fbf348e80bd8811acb4f62b5952"
+checksum = "a8aa3edc9087c29f51e753c6eebb7740e3140a519feb08f89443e5fd16a69b91"
 dependencies = [
  "crossterm",
  "ratatui",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2256,9 +2257,9 @@ checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unicode_categories"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,23 +1345,6 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e2e4cd95294a85c3b4446e63ef054eea43e0205b1fd60120c16b74ff7ff96ad"
-dependencies = [
- "bitflags 2.3.3",
- "cassowary",
- "crossterm",
- "indoc",
- "itertools 0.11.0",
- "paste",
- "strum",
- "unicode-segmentation",
- "unicode-width",
-]
-
-[[package]]
-name = "ratatui"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ebc917cfb527a566c37ecb94c7e3fd098353516fb4eb6bea17015ade0182425"
@@ -2214,7 +2197,7 @@ dependencies = [
  "git2",
  "log",
  "path-absolutize",
- "ratatui 0.24.0",
+ "ratatui",
  "rayon",
  "scopeguard",
  "serde",
@@ -2235,7 +2218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8aa3edc9087c29f51e753c6eebb7740e3140a519feb08f89443e5fd16a69b91"
 dependencies = [
  "crossterm",
- "ratatui 0.23.0",
+ "ratatui",
  "unicode-width",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ git2 = { version = "0.18.1", default-features = false }
 rayon = "1.8.0"
 fuzzy-matcher = "0.3.7"
 path-absolutize = "3.1.1"
-tui-textarea = { version = "0.2.2", features = ["ratatui-crossterm"], default-features=false}
+tui-textarea = "0.3.0"
 ratatui = { version = "0.23.0", features = ["all-widgets"]}
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rayon = "1.8.0"
 fuzzy-matcher = "0.3.7"
 path-absolutize = "3.1.1"
 tui-textarea = "0.3.0"
-ratatui = { version = "0.23.0", features = ["all-widgets"]}
+ratatui = { version = "0.24.0", features = ["all-widgets"]}
 
 [features]
 default = ["json", "sqlite"]

--- a/src/app/ui/editor/mod.rs
+++ b/src/app/ui/editor/mod.rs
@@ -1,6 +1,5 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
 use ratatui::{
-    backend::Backend,
     layout::Rect,
     prelude::Margin,
     style::{Color, Modifier, Style},
@@ -195,10 +194,7 @@ impl<'a> Editor<'a> {
         }
     }
 
-    pub fn render_widget<B>(&mut self, frame: &mut Frame<B>, area: Rect)
-    where
-        B: Backend,
-    {
+    pub fn render_widget(&mut self, frame: &mut Frame, area: Rect) {
         let mut title = "Content".to_owned();
         if self.is_active {
             let mode_caption = if self.is_insert_mode() {
@@ -248,10 +244,7 @@ impl<'a> Editor<'a> {
         self.render_horizontal_scrollbar(frame, area);
     }
 
-    pub fn render_vertical_scrollbar<B>(&mut self, frame: &mut Frame<B>, area: Rect)
-    where
-        B: Backend,
-    {
+    pub fn render_vertical_scrollbar(&mut self, frame: &mut Frame, area: Rect) {
         let lines_count = self.text_area.lines().len() as u16;
 
         if lines_count <= area.height - 2 {
@@ -278,10 +271,7 @@ impl<'a> Editor<'a> {
         frame.render_stateful_widget(scrollbar, scroll_area, &mut state);
     }
 
-    pub fn render_horizontal_scrollbar<B>(&mut self, frame: &mut Frame<B>, area: Rect)
-    where
-        B: Backend,
-    {
+    pub fn render_horizontal_scrollbar(&mut self, frame: &mut Frame, area: Rect) {
         let max_width = self
             .text_area
             .lines()

--- a/src/app/ui/editor/mod.rs
+++ b/src/app/ui/editor/mod.rs
@@ -245,9 +245,9 @@ impl<'a> Editor<'a> {
     }
 
     pub fn render_vertical_scrollbar(&mut self, frame: &mut Frame, area: Rect) {
-        let lines_count = self.text_area.lines().len() as u16;
+        let lines_count = self.text_area.lines().len();
 
-        if lines_count <= area.height - 2 {
+        if lines_count as u16 <= area.height - 2 {
             return;
         }
 
@@ -255,7 +255,7 @@ impl<'a> Editor<'a> {
 
         let mut state = ScrollbarState::default()
             .content_length(lines_count)
-            .position(row as u16);
+            .position(row);
 
         let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
             .begin_symbol(Some("▲"))
@@ -278,9 +278,9 @@ impl<'a> Editor<'a> {
             .iter()
             .map(|line| line.len())
             .max()
-            .unwrap_or_default() as u16;
+            .unwrap_or_default();
 
-        if max_width <= area.width - 2 {
+        if max_width as u16 <= area.width - 2 {
             return;
         }
 
@@ -288,7 +288,7 @@ impl<'a> Editor<'a> {
 
         let mut state = ScrollbarState::default()
             .content_length(max_width)
-            .position(col as u16);
+            .position(col);
 
         let scrollbar = Scrollbar::new(ScrollbarOrientation::HorizontalBottom)
             .begin_symbol(Some("◄"))

--- a/src/app/ui/entries_list/mod.rs
+++ b/src/app/ui/entries_list/mod.rs
@@ -125,7 +125,7 @@ impl<'a> EntriesList {
             })
             .collect();
 
-        let items_count = items.len() as u16;
+        let items_count = items.len();
 
         let list = List::new(items)
             .block(self.get_list_block(app.filter.is_some()))
@@ -139,15 +139,15 @@ impl<'a> EntriesList {
 
         frame.render_stateful_widget(list, area, &mut self.state);
 
-        let lines_count = lines_count as u16;
+        let lines_count = lines_count;
 
-        if lines_count > area.height - 2 {
+        if lines_count > area.height as usize - 2 {
             let avg_item_height = lines_count / items_count;
 
             self.render_scrollbar(
                 frame,
                 area,
-                self.state.selected().unwrap_or(0) as u16,
+                self.state.selected().unwrap_or(0),
                 items_count,
                 avg_item_height,
             );
@@ -158,16 +158,16 @@ impl<'a> EntriesList {
         &mut self,
         frame: &mut Frame,
         area: Rect,
-        pos: u16,
-        items_count: u16,
-        avg_item_height: u16,
+        pos: usize,
+        items_count: usize,
+        avg_item_height: usize,
     ) {
         const VIEWPORT_ADJUST: u16 = 4;
-        let viewport_len = (area.height / avg_item_height).saturating_sub(VIEWPORT_ADJUST);
+        let viewport_len = (area.height / avg_item_height as u16).saturating_sub(VIEWPORT_ADJUST);
 
         let mut state = ScrollbarState::default()
             .content_length(items_count)
-            .viewport_content_length(viewport_len)
+            .viewport_content_length(viewport_len as usize)
             .position(pos);
 
         let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)

--- a/src/app/ui/entries_list/mod.rs
+++ b/src/app/ui/entries_list/mod.rs
@@ -1,7 +1,6 @@
 use chrono::Datelike;
 
 use ratatui::{
-    backend::Backend,
     layout::{Alignment, Rect},
     prelude::Margin,
     style::{Color, Modifier, Style},
@@ -41,12 +40,7 @@ impl<'a> EntriesList {
         }
     }
 
-    fn render_list<B: Backend, D: DataProvider>(
-        &mut self,
-        frame: &mut Frame<B>,
-        app: &App<D>,
-        area: Rect,
-    ) {
+    fn render_list<D: DataProvider>(&mut self, frame: &mut Frame, app: &App<D>, area: Rect) {
         let (foreground_color, highlight_bg) = if self.is_active {
             (ACTIVE_CONTROL_COLOR, Color::LightGreen)
         } else {
@@ -160,9 +154,9 @@ impl<'a> EntriesList {
         }
     }
 
-    fn render_scrollbar<B: Backend>(
+    fn render_scrollbar(
         &mut self,
-        frame: &mut Frame<B>,
+        frame: &mut Frame,
         area: Rect,
         pos: u16,
         items_count: u16,
@@ -190,9 +184,9 @@ impl<'a> EntriesList {
         frame.render_stateful_widget(scrollbar, scroll_area, &mut state);
     }
 
-    fn render_place_holder<B: Backend>(
+    fn render_place_holder(
         &mut self,
-        frame: &mut Frame<B>,
+        frame: &mut Frame,
         area: Rect,
         list_keymaps: &[Keymap],
         has_filter: bool,
@@ -243,9 +237,9 @@ impl<'a> EntriesList {
             .border_style(border_style)
     }
 
-    pub fn render_widget<B: Backend, D: DataProvider>(
+    pub fn render_widget<D: DataProvider>(
         &mut self,
-        frame: &mut Frame<B>,
+        frame: &mut Frame,
         area: Rect,
         app: &App<D>,
         list_keymaps: &[Keymap],

--- a/src/app/ui/entry_popup/mod.rs
+++ b/src/app/ui/entry_popup/mod.rs
@@ -2,7 +2,6 @@ use anyhow::Ok;
 use chrono::{Datelike, Local, NaiveDate, TimeZone, Utc};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
-    backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Style},
     widgets::{Block, Borders, Clear, Paragraph, Wrap},

--- a/src/app/ui/entry_popup/mod.rs
+++ b/src/app/ui/entry_popup/mod.rs
@@ -116,7 +116,7 @@ impl<'a> EntryPopup<'a> {
         entry_pupop
     }
 
-    pub fn render_widget<B: Backend>(&mut self, frame: &mut Frame<B>, area: Rect) {
+    pub fn render_widget(&mut self, frame: &mut Frame, area: Rect) {
         let mut area = centered_rect_exact_height(70, 14, area);
 
         const FOOTER_LEN: u16 = FOOTER_TEXT.len() as u16 + FOOTER_MARGINE;

--- a/src/app/ui/entry_popup/tags.rs
+++ b/src/app/ui/entry_popup/tags.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeSet;
 
 use crossterm::event::{KeyCode, KeyModifiers};
 use ratatui::{
-    backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     widgets::{Block, BorderType, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
@@ -62,7 +61,7 @@ impl TagsPopup {
         tags_popup
     }
 
-    pub fn render_widget<B: Backend>(&mut self, frame: &mut Frame<B>, area: Rect) {
+    pub fn render_widget(&mut self, frame: &mut Frame, area: Rect) {
         let mut area = centered_rect(70, 100, area);
         area.y += 1;
         area.height -= 2;
@@ -106,7 +105,7 @@ impl TagsPopup {
         frame.render_widget(footer, chunks[1]);
     }
 
-    fn render_tags_list<B: Backend>(&mut self, frame: &mut Frame<B>, area: Rect) {
+    fn render_tags_list(&mut self, frame: &mut Frame, area: Rect) {
         let items: Vec<ListItem> = self
             .tags
             .iter()
@@ -135,7 +134,7 @@ impl TagsPopup {
         frame.render_stateful_widget(list, area, &mut self.state);
     }
 
-    fn render_tags_place_holder<B: Backend>(&mut self, frame: &mut Frame<B>, area: Rect) {
+    fn render_tags_place_holder(&mut self, frame: &mut Frame, area: Rect) {
         let place_holder_text = String::from("\nNo journals with tags provided");
 
         let place_holder = Paragraph::new(place_holder_text)

--- a/src/app/ui/export_popup/mod.rs
+++ b/src/app/ui/export_popup/mod.rs
@@ -3,7 +3,6 @@ use std::{env, path::PathBuf};
 use backend::{DataProvider, Entry};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
-    backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::Style,
     widgets::{Block, Borders, Clear, Paragraph, Wrap},

--- a/src/app/ui/export_popup/mod.rs
+++ b/src/app/ui/export_popup/mod.rs
@@ -121,7 +121,7 @@ impl<'a> ExportPopup<'a> {
         self.entry_id.is_none()
     }
 
-    pub fn render_widget<B: Backend>(&mut self, frame: &mut Frame<B>, area: Rect) {
+    pub fn render_widget(&mut self, frame: &mut Frame, area: Rect) {
         let mut area = centered_rect_exact_height(70, 11, area);
 
         if area.width < FOOTER_TEXT.len() as u16 + FOOTER_MARGINE {

--- a/src/app/ui/filter_popup/mod.rs
+++ b/src/app/ui/filter_popup/mod.rs
@@ -2,7 +2,6 @@ use std::collections::HashSet;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
-    backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     widgets::{Block, BorderType, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
@@ -85,7 +84,7 @@ impl<'a> FilterPopup<'a> {
         filter_popup
     }
 
-    pub fn render_widget<B: Backend>(&mut self, frame: &mut Frame<B>, area: Rect) {
+    pub fn render_widget(&mut self, frame: &mut Frame, area: Rect) {
         let area = centered_rect(70, 80, area);
 
         let block = Block::default().borders(Borders::ALL).title("Filter");
@@ -126,7 +125,7 @@ impl<'a> FilterPopup<'a> {
     }
 
     #[inline]
-    fn render_relations<B: Backend>(&mut self, frame: &mut Frame<B>, area: Rect) {
+    fn render_relations(&mut self, frame: &mut Frame, area: Rect) {
         let relation_text = match self.relation {
             CriteriaRelation::And => "Journals must meet all criteria",
             CriteriaRelation::Or => "Journals must meet any of the criteria",
@@ -145,12 +144,7 @@ impl<'a> FilterPopup<'a> {
     }
 
     #[inline]
-    fn render_text_boxes<B: Backend>(
-        &mut self,
-        frame: &mut Frame<B>,
-        title_area: Rect,
-        content_area: Rect,
-    ) {
+    fn render_text_boxes(&mut self, frame: &mut Frame, title_area: Rect, content_area: Rect) {
         let active_cursor_style = Style::default().bg(ACTIVE_BORDER_COLOR).fg(Color::Black);
         let deactivate_cursor_style = Style::default().bg(Color::Reset);
 
@@ -186,7 +180,7 @@ impl<'a> FilterPopup<'a> {
     }
 
     #[inline]
-    fn render_tags_list<B: Backend>(&mut self, frame: &mut Frame<B>, area: Rect) {
+    fn render_tags_list(&mut self, frame: &mut Frame, area: Rect) {
         let items: Vec<ListItem> = self
             .tags
             .iter()
@@ -217,7 +211,7 @@ impl<'a> FilterPopup<'a> {
     }
 
     #[inline]
-    fn render_tags_place_holder<B: Backend>(&mut self, frame: &mut Frame<B>, area: Rect) {
+    fn render_tags_place_holder(&mut self, frame: &mut Frame, area: Rect) {
         let place_holder_text = String::from("\nNo journals with tags provided");
 
         let place_holder = Paragraph::new(place_holder_text)
@@ -242,7 +236,7 @@ impl<'a> FilterPopup<'a> {
     }
 
     #[inline]
-    fn render_footer<B: Backend>(&mut self, frame: &mut Frame<B>, area: Rect) {
+    fn render_footer(&mut self, frame: &mut Frame, area: Rect) {
         let footer = Paragraph::new(FOOTER_TEXT)
             .alignment(Alignment::Center)
             .wrap(Wrap { trim: false })

--- a/src/app/ui/footer.rs
+++ b/src/app/ui/footer.rs
@@ -1,6 +1,5 @@
 use backend::DataProvider;
 use ratatui::{
-    backend::Backend,
     layout::{Alignment, Rect},
     style::Style,
     widgets::{Block, Borders, Paragraph, Wrap},
@@ -13,8 +12,8 @@ use super::{ControlType, UICommand, UIComponents};
 
 const SEPARATOR: &str = " | ";
 
-pub fn render_footer<B: Backend, D: DataProvider>(
-    frame: &mut Frame<B>,
+pub fn render_footer<D: DataProvider>(
+    frame: &mut Frame,
     area: Rect,
     ui_components: &UIComponents,
     app: &App<D>,

--- a/src/app/ui/fuzz_find/mod.rs
+++ b/src/app/ui/fuzz_find/mod.rs
@@ -62,7 +62,7 @@ impl<'a> FuzzFindPopup<'a> {
         }
     }
 
-    pub fn render_widget<B: Backend>(&mut self, frame: &mut Frame<B>, area: Rect) {
+    pub fn render_widget(&mut self, frame: &mut Frame, area: Rect) {
         let area = centered_rect(60, 60, area);
 
         let block = Block::default()
@@ -99,7 +99,7 @@ impl<'a> FuzzFindPopup<'a> {
     }
 
     #[inline]
-    fn render_entries_list<B: Backend>(&mut self, frame: &mut Frame<B>, area: Rect) {
+    fn render_entries_list(&mut self, frame: &mut Frame, area: Rect) {
         let items: Vec<ListItem> = self
             .filtered_entries
             .iter()
@@ -143,7 +143,7 @@ impl<'a> FuzzFindPopup<'a> {
     }
 
     #[inline]
-    fn render_footer<B: Backend>(&mut self, frame: &mut Frame<B>, area: Rect) {
+    fn render_footer(&mut self, frame: &mut Frame, area: Rect) {
         let footer = Paragraph::new(FOOTER_TEXT)
             .alignment(Alignment::Center)
             .wrap(Wrap { trim: false })

--- a/src/app/ui/fuzz_find/mod.rs
+++ b/src/app/ui/fuzz_find/mod.rs
@@ -3,7 +3,6 @@ use std::{collections::HashMap, usize};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 use ratatui::{
-    backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},

--- a/src/app/ui/help_popup/mod.rs
+++ b/src/app/ui/help_popup/mod.rs
@@ -109,7 +109,7 @@ impl HelpPopup {
         }
     }
 
-    pub fn render_widget<B: Backend>(&mut self, frame: &mut Frame<B>, area: Rect) {
+    pub fn render_widget(&mut self, frame: &mut Frame, area: Rect) {
         let area = centered_rect(90, 80, area);
         let block = Block::default().title("Help").borders(Borders::ALL);
         frame.render_widget(Clear, area);
@@ -188,11 +188,7 @@ impl HelpPopup {
     }
 }
 
-fn render_keybindings<B: Backend, T: KeybindingsTable>(
-    frame: &mut Frame<B>,
-    area: Rect,
-    table: &mut T,
-) {
+fn render_keybindings<T: KeybindingsTable>(frame: &mut Frame, area: Rect, table: &mut T) {
     let header_cells = ["Key", "Command", "Description"]
         .into_iter()
         .map(|header| Cell::from(header).style(Style::default().fg(Color::LightBlue)));
@@ -267,7 +263,7 @@ fn render_keybindings<B: Backend, T: KeybindingsTable>(
     }
 }
 
-fn render_scrollbar<B: Backend>(frame: &mut Frame<B>, area: Rect, pos: u16, items_count: u16) {
+fn render_scrollbar(frame: &mut Frame, area: Rect, pos: u16, items_count: u16) {
     const VIEWPORT_ADJUST: u16 = 13;
 
     let viewport_len = area.height.saturating_sub(VIEWPORT_ADJUST);
@@ -291,7 +287,7 @@ fn render_scrollbar<B: Backend>(frame: &mut Frame<B>, area: Rect, pos: u16, item
     frame.render_stateful_widget(scrollbar, scroll_area, &mut state);
 }
 
-pub fn render_editor_hint<B: Backend>(frame: &mut Frame<B>, area: Rect) {
+pub fn render_editor_hint(frame: &mut Frame, area: Rect) {
     let paragraph = Paragraph::new(EDITOR_HINT_TEXT)
         .block(
             Block::default()

--- a/src/app/ui/help_popup/mod.rs
+++ b/src/app/ui/help_popup/mod.rs
@@ -1,6 +1,5 @@
 use crossterm::event::{KeyCode, KeyModifiers};
 use ratatui::{
-    backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     prelude::Margin,
     style::{Color, Modifier, Style},
@@ -231,7 +230,7 @@ fn render_keybindings<T: KeybindingsTable>(frame: &mut Frame, area: Rect, table:
         Row::new(cells).height(height)
     });
 
-    let items_len = rows.len() as u16;
+    let items_len = rows.len();
 
     let keymaps_table = Table::new(rows)
         .header(header)
@@ -254,23 +253,18 @@ fn render_keybindings<T: KeybindingsTable>(frame: &mut Frame, area: Rect, table:
     let has_scrollbar = lines_count > area.height;
 
     if has_scrollbar {
-        render_scrollbar(
-            frame,
-            area,
-            table_state.selected().unwrap_or(0) as u16,
-            items_len,
-        );
+        render_scrollbar(frame, area, table_state.selected().unwrap_or(0), items_len);
     }
 }
 
-fn render_scrollbar(frame: &mut Frame, area: Rect, pos: u16, items_count: u16) {
+fn render_scrollbar(frame: &mut Frame, area: Rect, pos: usize, items_count: usize) {
     const VIEWPORT_ADJUST: u16 = 13;
 
     let viewport_len = area.height.saturating_sub(VIEWPORT_ADJUST);
 
     let mut state = ScrollbarState::default()
         .content_length(items_count)
-        .viewport_content_length(viewport_len)
+        .viewport_content_length(viewport_len as usize)
         .position(pos);
 
     let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -117,10 +117,9 @@ impl<'a, 'b> UIComponents<'a> {
         self.editor.set_current_entry(entry_id, app);
     }
 
-    pub fn render_ui<D, B>(&mut self, f: &mut Frame<B>, app: &'b App<D>)
+    pub fn render_ui<D>(&mut self, f: &mut Frame, app: &'b App<D>)
     where
         D: DataProvider,
-        B: Backend,
     {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
@@ -141,10 +140,7 @@ impl<'a, 'b> UIComponents<'a> {
         self.render_popup(f);
     }
 
-    pub fn render_popup<B>(&mut self, f: &mut Frame<B>)
-    where
-        B: Backend,
-    {
+    pub fn render_popup(&mut self, f: &mut Frame) {
         if let Some(popup) = self.popup_stack.last_mut() {
             match popup {
                 Popup::Help(help_popup) => help_popup.render_widget(f, f.size()),

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -25,7 +25,6 @@ use super::{
 use anyhow::Result;
 
 use ratatui::{
-    backend::Backend,
     layout::{Constraint, Direction, Layout},
     style::Color,
     Frame,

--- a/src/app/ui/msg_box/mod.rs
+++ b/src/app/ui/msg_box/mod.rs
@@ -1,6 +1,5 @@
 use crossterm::event::KeyCode;
 use ratatui::{
-    backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Style},
     text::Span,
@@ -57,7 +56,7 @@ impl MsgBox {
         Self { msg_type, actions }
     }
 
-    pub fn render_widget<B: Backend>(&mut self, frame: &mut Frame<B>, area: Rect) {
+    pub fn render_widget(&mut self, frame: &mut Frame, area: Rect) {
         let area = centered_rect_exact_height(55, 8, area);
 
         let (title, color, text) = match &self.msg_type {

--- a/src/app/ui/ui_functions.rs
+++ b/src/app/ui/ui_functions.rs
@@ -1,5 +1,4 @@
 use ratatui::{
-    backend::Backend,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     widgets::{Block, BorderType, Borders, Clear, Paragraph},
     Frame,

--- a/src/app/ui/ui_functions.rs
+++ b/src/app/ui/ui_functions.rs
@@ -86,7 +86,7 @@ pub fn centered_rect_exact_dimensions(width: u16, height: u16, r: Rect) -> Rect 
         .split(popup_layout[1])[1]
 }
 
-pub fn render_message_centered<B: Backend>(frame: &mut Frame<B>, message: &str) {
+pub fn render_message_centered(frame: &mut Frame, message: &str) {
     const TEXT_MARGIN: u16 = 4;
     const HEIGHT_MARGIN: u16 = 2;
 


### PR DESCRIPTION
This PR Upgrades the crates `ratatui` and `tui-textarea`

- `ratatui` has been updated to 0.24 which introduced the following breaking changes:
1. Backend isn't a generic argument anymore
2. Scrollbar state changed its arguments from u16 to usize

- `tui-textarea` uses ratatui as the default feature and it doesn't depend on a specific version from it anymore.