### PR TITLE
Added: Visual Mode to Built-in Editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ TUI-Journal is a terminal-based application written in Rust that allows you to w
 - Search functions for journals title and content in the built-in filter.
 - Control many journals at once via the multi-select mode
 - Keybindings is a combination of VIM and Emacs motions (VIM for navigation and Emacs for editing texts in edit-mode).
+- Utilize Editor's Visual Mode for VIM-style text selection, copying, and deletion.
 - Export and Import journals between different back-end files.
 - Export the current journal's content to a predefined export path or the current directory 
 - See the keybindings from inside the app

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -216,15 +216,19 @@ pub(crate) fn get_editor_mode_keymaps() -> Vec<Keymap> {
         ),
         Keymap::new(
             Input::new(KeyCode::Esc, KeyModifiers::NONE),
-            UICommand::FinishEditEntryContent,
+            UICommand::BackEditorNormalMode,
         ),
         Keymap::new(
             Input::new(KeyCode::Char('c'), KeyModifiers::CONTROL),
-            UICommand::FinishEditEntryContent,
+            UICommand::BackEditorNormalMode,
         ),
         Keymap::new(
             Input::new(KeyCode::Char('['), KeyModifiers::CONTROL),
-            UICommand::FinishEditEntryContent,
+            UICommand::BackEditorNormalMode,
+        ),
+        Keymap::new(
+            Input::new(KeyCode::Char('v'), KeyModifiers::NONE),
+            UICommand::ToggleEditorVisualMode,
         ),
     ]
 }

--- a/src/app/ui/commands/editor_cmd.rs
+++ b/src/app/ui/commands/editor_cmd.rs
@@ -4,9 +4,9 @@ use backend::DataProvider;
 
 use super::CmdResult;
 
-pub fn exec_finish_editing(ui_components: &mut UIComponents) -> CmdResult {
+pub fn exec_back_editor_to_normal_mode(ui_components: &mut UIComponents) -> CmdResult {
     if ui_components.active_control == ControlType::EntryContentTxt
-        && ui_components.editor.is_insert_mode()
+        && ui_components.editor.is_prioritized()
     {
         ui_components.editor.set_editor_mode(EditorMode::Normal);
     }
@@ -61,4 +61,16 @@ pub fn discard_current_content<D: DataProvider>(
     ui_components
         .editor
         .set_current_entry(app.current_entry_id, app);
+}
+
+pub fn exec_toggle_editor_visual_mode(ui_components: &mut UIComponents) -> CmdResult {
+    debug_assert!(ui_components.active_control == ControlType::EntryContentTxt);
+
+    match ui_components.editor.get_editor_mode() {
+        EditorMode::Normal => ui_components.editor.set_editor_mode(EditorMode::Visual),
+        EditorMode::Visual => ui_components.editor.set_editor_mode(EditorMode::Normal),
+        EditorMode::Insert => return Ok(HandleInputReturnType::NotFound),
+    }
+
+    Ok(HandleInputReturnType::Handled)
 }

--- a/src/app/ui/commands/editor_cmd.rs
+++ b/src/app/ui/commands/editor_cmd.rs
@@ -8,7 +8,7 @@ pub fn exec_finish_editing(ui_components: &mut UIComponents) -> CmdResult {
     if ui_components.active_control == ControlType::EntryContentTxt
         && ui_components.editor.is_insert_mode()
     {
-        ui_components.editor.mode = EditorMode::Normal;
+        ui_components.editor.set_editor_mode(EditorMode::Normal);
     }
 
     Ok(HandleInputReturnType::Handled)

--- a/src/app/ui/commands/mod.rs
+++ b/src/app/ui/commands/mod.rs
@@ -28,7 +28,7 @@ pub enum UICommand {
     EditCurrentEntry,
     DeleteCurrentEntry,
     StartEditEntryContent,
-    FinishEditEntryContent,
+    BackEditorNormalMode,
     SaveEntryContent,
     DiscardChangesEntryContent,
     ReloadAll,
@@ -45,6 +45,7 @@ pub enum UICommand {
     ShowFilter,
     ResetFilter,
     ShowFuzzyFind,
+    ToggleEditorVisualMode,
 }
 
 #[derive(Debug, Clone)]
@@ -96,8 +97,8 @@ impl UICommand {
                 "Edit journal content",
                 "Start editing current journal entry content in editor",
             ),
-            UICommand::FinishEditEntryContent => {
-                CommandInfo::new("End edit mode", "Exit edit mode in editor")
+            UICommand::BackEditorNormalMode => {
+                CommandInfo::new("Back to Editor Normal Mode", "Exit editor special modes (insert, visual) and go back to normal mode")
             }
             UICommand::SaveEntryContent => {
                 CommandInfo::new("Save", "Save changes on journal content")
@@ -157,6 +158,11 @@ impl UICommand {
                 "Fuzzy find",
                 "Open fuzzy find popup for journals",
             ),
+            UICommand::ToggleEditorVisualMode => CommandInfo::new(
+                "Toggle Editor Visual Mode",
+                "Toggle Editor Visual(Select) Mode",
+            ),
+
         }
     }
 
@@ -176,7 +182,7 @@ impl UICommand {
             UICommand::EditCurrentEntry => exec_edit_current_entry(ui_components, app),
             UICommand::DeleteCurrentEntry => exec_delete_current_entry(ui_components, app),
             UICommand::StartEditEntryContent => exec_start_edit_content(ui_components),
-            UICommand::FinishEditEntryContent => exec_finish_editing(ui_components),
+            UICommand::BackEditorNormalMode => exec_back_editor_to_normal_mode(ui_components),
             UICommand::SaveEntryContent => exec_save_entry_content(ui_components, app).await,
             UICommand::DiscardChangesEntryContent => exec_discard_content(ui_components),
             UICommand::ReloadAll => exec_reload_all(ui_components, app).await,
@@ -195,6 +201,7 @@ impl UICommand {
             UICommand::ShowFilter => exec_show_filter(ui_components, app),
             UICommand::ResetFilter => exec_reset_filter(app),
             UICommand::ShowFuzzyFind => exec_show_fuzzy_find(ui_components, app),
+            UICommand::ToggleEditorVisualMode => exec_toggle_editor_visual_mode(ui_components),
         }
     }
 
@@ -226,7 +233,7 @@ impl UICommand {
                 continue_delete_current_entry(app, msg_box_result).await
             }
             UICommand::StartEditEntryContent => not_implemented(),
-            UICommand::FinishEditEntryContent => not_implemented(),
+            UICommand::BackEditorNormalMode => not_implemented(),
             UICommand::SaveEntryContent => not_implemented(),
             UICommand::DiscardChangesEntryContent => {
                 continue_discard_content(ui_components, app, msg_box_result)
@@ -255,6 +262,7 @@ impl UICommand {
             UICommand::ShowFuzzyFind => {
                 continue_fuzzy_find(ui_components, app, msg_box_result).await
             }
+            UICommand::ToggleEditorVisualMode => not_implemented(),
         }
     }
 }

--- a/src/app/ui/commands/mod.rs
+++ b/src/app/ui/commands/mod.rs
@@ -116,7 +116,7 @@ impl UICommand {
             ),
             UICommand::EnterMultiSelectMode => CommandInfo::new(
                 "Enter journals multi selection mode",
-                "Enter multi selection mode for journals to work with multi journals at once",
+                "Enter multi selection mode for journals when journals list is in focus to work with multi journals at once",
             ),
             UICommand::LeaveMultiSelectMode => CommandInfo::new(
                 "Leave journals multi selection mode",
@@ -160,7 +160,7 @@ impl UICommand {
             ),
             UICommand::ToggleEditorVisualMode => CommandInfo::new(
                 "Toggle Editor Visual Mode",
-                "Toggle Editor Visual(Select) Mode",
+                "Toggle Editor Visual(Select) Mode when editor is in focus",
             ),
 
         }

--- a/src/app/ui/editor/mod.rs
+++ b/src/app/ui/editor/mod.rs
@@ -26,7 +26,7 @@ pub enum EditorMode {
 
 pub struct Editor<'a> {
     text_area: TextArea<'a>,
-    pub mode: EditorMode,
+    mode: EditorMode,
     is_active: bool,
     is_dirty: bool,
     has_unsaved: bool,

--- a/src/app/ui/editor/mod.rs
+++ b/src/app/ui/editor/mod.rs
@@ -126,7 +126,7 @@ impl<'a> Editor<'a> {
         if is_default_navigation(input) {
             let key_event = KeyEvent::from(input);
             self.text_area.input(key_event);
-        } else {
+        } else if !self.is_visual_mode() || !self.handle_input_visual_only(input) {
             self.handle_vim_motions(input);
         }
 
@@ -135,6 +135,31 @@ impl<'a> Editor<'a> {
             self.set_editor_mode(EditorMode::Normal);
         }
         Ok(HandleInputReturnType::Handled)
+    }
+
+    /// Handles input specialized for visual mode only like cut and copy
+    fn handle_input_visual_only(&mut self, input: &Input) -> bool {
+        if !input.modifiers.is_empty() {
+            return false;
+        }
+
+        match input.key_code {
+            KeyCode::Char('d') => {
+                self.text_area.cut();
+                true
+            }
+            KeyCode::Char('y') => {
+                self.text_area.copy();
+                self.set_editor_mode(EditorMode::Normal);
+                true
+            }
+            KeyCode::Char('c') => {
+                self.text_area.cut();
+                self.set_editor_mode(EditorMode::Insert);
+                true
+            }
+            _ => false,
+        }
     }
 
     fn handle_vim_motions(&mut self, input: &Input) {

--- a/src/app/ui/editor/mod.rs
+++ b/src/app/ui/editor/mod.rs
@@ -129,6 +129,11 @@ impl<'a> Editor<'a> {
         } else {
             self.handle_vim_motions(input);
         }
+
+        // Check if the input led the editor to leave the visual mode and make the corresponding UI changes
+        if !self.text_area.is_selecting() && self.is_visual_mode() {
+            self.set_editor_mode(EditorMode::Normal);
+        }
         Ok(HandleInputReturnType::Handled)
     }
 

--- a/src/app/ui/footer.rs
+++ b/src/app/ui/footer.rs
@@ -43,7 +43,7 @@ fn get_editor_mode_text(ui_components: &UIComponents) -> String {
     let exit_editor_mode_keymap: Vec<_> = ui_components
         .editor_keymaps
         .iter()
-        .filter(|keymap| keymap.command == UICommand::FinishEditEntryContent)
+        .filter(|keymap| keymap.command == UICommand::BackEditorNormalMode)
         .collect();
 
     format!(

--- a/src/app/ui/help_popup/mod.rs
+++ b/src/app/ui/help_popup/mod.rs
@@ -34,7 +34,8 @@ const TAB_LETTER_HIGHLIGHT_COLOR: Color = Color::LightGreen;
 
 const EDITOR_HINT_TEXT: &str = r"The Editor has two modes:
  - Normal-Mode: In this mode VIM keybindings are used to navigate the text and to enter edit mode via (i, I, a , A, o, O).
- - Edit-Mode: In this mode Emacs keybindings are used to edit and navigate the text.";
+ - Edit-Mode: In this mode Emacs keybindings are used to edit and navigate the text.
+ - Visual-Mode: Like the visual mode in VIM to select, delete and yank text with extra vim keybindings (d, y, c)";
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum KeybindingsTabs {

--- a/src/app/ui/help_popup/mod.rs
+++ b/src/app/ui/help_popup/mod.rs
@@ -28,7 +28,7 @@ mod multi_select_bindings;
 const KEY_PERC: u16 = 18;
 const NAME_PERC: u16 = 27;
 const DESCRIPTION_PERC: u16 = 100 - NAME_PERC - KEY_PERC;
-const MARGINE: u16 = 8;
+const MARGIN: u16 = 8;
 
 const TAB_LETTER_HIGHLIGHT_COLOR: Color = Color::LightGreen;
 
@@ -206,9 +206,9 @@ fn render_keybindings<T: KeybindingsTable>(frame: &mut Frame, area: Rect, table:
         } = command.get_info();
 
         // Text wrapping
-        let keys_width = (area.width - MARGINE) * KEY_PERC / 100;
+        let keys_width = (area.width - MARGIN) * KEY_PERC / 100;
         let name_width = area.width * NAME_PERC / 100;
-        let description_width = (area.width - MARGINE) * DESCRIPTION_PERC / 100;
+        let description_width = (area.width - MARGIN) * DESCRIPTION_PERC / 100;
 
         keys_text = textwrap::fill(keys_text.as_str(), keys_width as usize);
         name = textwrap::fill(name.as_str(), name_width as usize);

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -346,7 +346,7 @@ impl<'a, 'b> UIComponents<'a> {
         self.change_active_control(ControlType::EntryContentTxt);
 
         assert!(!self.editor.is_insert_mode());
-        self.editor.mode = EditorMode::Insert;
+        self.editor.set_editor_mode(EditorMode::Insert);
         Ok(HandleInputReturnType::Handled)
     }
 

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -162,11 +162,14 @@ impl<'a, 'b> UIComponents<'a> {
             return self.handle_popup_input(input, app).await;
         }
 
-        if self.editor.is_insert_mode() {
+        if self.editor.is_prioritized() {
             if let Some(key) = self.editor_keymaps.iter().find(|c| &c.key == input) {
                 return key.command.clone().execute(self, app).await;
             }
-            return self.editor.handle_input(input, app);
+            let handle_result = self.editor.handle_input_prioritized(input, app)?;
+            if matches!(handle_result, HandleInputReturnType::Handled) {
+                return Ok(handle_result);
+            }
         }
 
         if self.entries_list.multi_select_mode {

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -49,6 +49,7 @@ pub const ACTIVE_CONTROL_COLOR: Color = Color::Reset;
 pub const INACTIVE_CONTROL_COLOR: Color = Color::Rgb(170, 170, 200);
 pub const EDITOR_MODE_COLOR: Color = Color::LightGreen;
 pub const INVALID_CONTROL_COLOR: Color = Color::LightRed;
+pub const VISUAL_MODE_COLOR: Color = Color::Blue;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ControlType {


### PR DESCRIPTION
This PR closes #238 

It adds visual mode for the editor Like in VIM with the ability to select, delete, yank text
Help popup inside the app and README in the repo have been updated with new functionality
