### PR TITLE
Ignore key events of types other than press

### DIFF
--- a/src/app/runner.rs
+++ b/src/app/runner.rs
@@ -95,10 +95,11 @@ where
         match handle_input(event, &mut app, &mut ui_components).await {
             Ok(result) => {
                 match result {
-                    HandleInputReturnType::Handled | HandleInputReturnType::NotFound => {
+                    HandleInputReturnType::Handled => {
                         ui_components.update_current_entry(&mut app);
                         draw_ui(terminal, &mut app, &mut ui_components)?;
                     }
+                    HandleInputReturnType::NotFound => {}
                     HandleInputReturnType::ExitApp => return Ok(()),
                 };
             }

--- a/src/app/runner.rs
+++ b/src/app/runner.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use crossterm::event::{Event, EventStream};
+use crossterm::event::{Event, EventStream, KeyEventKind};
 use ratatui::{backend::Backend, Terminal};
 
 use crate::app::{App, UIComponents};
@@ -152,9 +152,13 @@ async fn handle_input<'a, D: DataProvider>(
     ui_components: &mut UIComponents<'a>,
 ) -> Result<HandleInputReturnType> {
     if let Event::Key(key) = event {
-        let input = Input::from(&key);
-
-        ui_components.handle_input(&input, app).await
+        match key.kind {
+            KeyEventKind::Press => {
+                let input = Input::from(&key);
+                ui_components.handle_input(&input, app).await
+            }
+            KeyEventKind::Repeat | KeyEventKind::Release => Ok(HandleInputReturnType::NotFound),
+        }
     } else {
         Ok(HandleInputReturnType::NotFound)
     }


### PR DESCRIPTION
This PR closes #266 

Since the version 0.26 of crossterm, two events for each key stroke is emitted on Windows (one for press and the other for release) [link](https://github.com/crossterm-rs/crossterm/issues/797), which will be eventually the default behavior on Linux as well. This breaking change led to double key registration on windows. 

With the PR:
- only the keys with the event kind "Press" will be caught and the rest will be ignored.
- The UI won't be re-rendered when the result `not-found` from a key press handling is returned.