### PR TITLE
Added: Add full screen mode

### DIFF
--- a/backend/tests/json/temp_file.rs
+++ b/backend/tests/json/temp_file.rs
@@ -30,4 +30,3 @@ impl Drop for TempFile {
         self.clean_up();
     }
 }
-

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -136,6 +136,10 @@ pub(crate) fn get_global_keymaps() -> Vec<Keymap> {
             Input::new(KeyCode::Char('y'), KeyModifiers::CONTROL),
             UICommand::EditInExternalEditor,
         ),
+        Keymap::new(
+            Input::new(KeyCode::Char('f'), KeyModifiers::CONTROL),
+            UICommand::ToggleFullScreenMode,
+        ),
     ]
 }
 

--- a/src/app/ui/commands/entries_list_cmd.rs
+++ b/src/app/ui/commands/entries_list_cmd.rs
@@ -428,3 +428,8 @@ pub async fn continue_fuzzy_find<'a, D: DataProvider>(
 
     Ok(HandleInputReturnType::Handled)
 }
+
+pub fn exec_toggle_full_screen_mode(ui_components: &mut UIComponents) -> CmdResult {
+    ui_components.fullscreen = !ui_components.fullscreen;
+    Ok(HandleInputReturnType::Handled)
+}

--- a/src/app/ui/commands/mod.rs
+++ b/src/app/ui/commands/mod.rs
@@ -55,6 +55,7 @@ pub enum UICommand {
     ResetFilter,
     ShowFuzzyFind,
     ToggleEditorVisualMode,
+    ToggleFullScreenMode,
     CopyOsClipboard,
     CutOsClipboard,
     PasteOsClipboard,
@@ -174,6 +175,10 @@ impl UICommand {
                 "Toggle Editor Visual Mode",
                 "Toggle Editor Visual(Select) Mode when editor is in focus",
             ),
+            UICommand::ToggleFullScreenMode => CommandInfo::new(
+                "Toggle Full Screen Mode",
+                "Maximize the currently selected view",
+            ),
             UICommand::CopyOsClipboard => CommandInfo::new(
                 "Copy to OS clipboard",
                 "Copy selection to operation system clipboard while in editor visual mode",
@@ -226,6 +231,7 @@ impl UICommand {
             UICommand::ResetFilter => exec_reset_filter(app),
             UICommand::ShowFuzzyFind => exec_show_fuzzy_find(ui_components, app),
             UICommand::ToggleEditorVisualMode => exec_toggle_editor_visual_mode(ui_components),
+            UICommand::ToggleFullScreenMode => exec_toggle_full_screen_mode(ui_components),
             UICommand::CopyOsClipboard => exec_copy_os_clipboard(ui_components),
             UICommand::CutOsClipboard => exec_cut_os_clipboard(ui_components),
             UICommand::PasteOsClipboard => exec_paste_os_clipboard(ui_components),
@@ -290,6 +296,7 @@ impl UICommand {
                 continue_fuzzy_find(ui_components, app, msg_box_result).await
             }
             UICommand::ToggleEditorVisualMode => not_implemented(),
+            UICommand::ToggleFullScreenMode => not_implemented(),
             UICommand::CopyOsClipboard => not_implemented(),
             UICommand::CutOsClipboard => not_implemented(),
             UICommand::PasteOsClipboard => not_implemented(),

--- a/src/app/ui/footer.rs
+++ b/src/app/ui/footer.rs
@@ -91,6 +91,15 @@ fn get_standard_text<D: DataProvider>(ui_components: &UIComponents, app: &App<D>
         }
     }
 
+    if ui_components.fullscreen {
+        let full_screen_keymap: Vec<_> = ui_components
+            .global_keymaps
+            .iter()
+            .filter(|keymap| keymap.command == UICommand::ToggleFullScreenMode)
+            .collect();
+        footer_parts.push(get_keymap_text(full_screen_keymap));
+    }
+
     let help_keymap: Vec<_> = ui_components
         .global_keymaps
         .iter()

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -76,6 +76,7 @@ pub struct UIComponents<'a> {
     popup_stack: Vec<Popup<'a>>,
     pub active_control: ControlType,
     pending_command: Option<UICommand>,
+    fullscreen: bool,
 }
 
 impl<'a, 'b> UIComponents<'a> {
@@ -100,6 +101,7 @@ impl<'a, 'b> UIComponents<'a> {
             popup_stack: Vec::new(),
             active_control,
             pending_command: None,
+            fullscreen: false,
         }
     }
 
@@ -127,15 +129,25 @@ impl<'a, 'b> UIComponents<'a> {
             .split(f.size());
 
         render_footer(f, chunks[1], self, app);
-
-        let entries_chunks = Layout::default()
-            .direction(Direction::Horizontal)
-            .constraints([Constraint::Percentage(30), Constraint::Percentage(70)].as_ref())
-            .split(chunks[0]);
-
-        self.entries_list
-            .render_widget(f, entries_chunks[0], app, &self.entries_list_keymaps);
-        self.editor.render_widget(f, entries_chunks[1]);
+        if self.fullscreen {
+            match self.active_control {
+                ControlType::EntriesList => {
+                    self.entries_list
+                        .render_widget(f, chunks[0], app, &self.entries_list_keymaps);
+                }
+                ControlType::EntryContentTxt => {
+                    self.editor.render_widget(f, chunks[0]);
+                }
+            }
+        } else {
+            let entries_chunks = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(30), Constraint::Percentage(70)].as_ref())
+                .split(chunks[0]);
+            self.entries_list
+                .render_widget(f, entries_chunks[0], app, &self.entries_list_keymaps);
+            self.editor.render_widget(f, entries_chunks[1]);
+        }
 
         self.render_popup(f);
     }


### PR DESCRIPTION
closes #271 

press ctrl+f to toggle full screen for the selected view:

![rec_20240104T222740](https://github.com/AmmarAbouZor/tui-journal/assets/24392180/51078ba5-dcb2-48ac-a0b6-106651500311)

> The command to switch between the active controls should exit full-screen mode if it active before

I personally liked the other way around (keep it full screen) but let me know if you want this behavior changed!