### PR TITLE
Changed: Main Footer Height is calculated dynamically

### DIFF
--- a/src/app/ui/footer.rs
+++ b/src/app/ui/footer.rs
@@ -12,21 +12,22 @@ use super::{ControlType, UICommand, UIComponents};
 
 const SEPARATOR: &str = " | ";
 
+pub fn get_footer_heigh<D: DataProvider>(
+    width: u16,
+    ui_components: &UIComponents,
+    app: &App<D>,
+) -> u16 {
+    let footer_text = get_footer_text(ui_components, app);
+    footer_text.len() as u16 / width + 1
+}
+
 pub fn render_footer<D: DataProvider>(
     frame: &mut Frame,
     area: Rect,
     ui_components: &UIComponents,
     app: &App<D>,
 ) {
-    let (edior_mode, multi_select_mode) = (
-        ui_components.editor.is_insert_mode(),
-        ui_components.entries_list.multi_select_mode,
-    );
-    let footer_text = match (edior_mode, multi_select_mode) {
-        (true, false) => get_editor_mode_text(ui_components),
-        (false, true) => get_multi_select_text(ui_components),
-        _ => get_standard_text(ui_components, app),
-    };
+    let footer_text = get_footer_text(ui_components, app);
     let footer = Paragraph::new(footer_text)
         .alignment(Alignment::Left)
         .wrap(Wrap { trim: false })
@@ -37,6 +38,18 @@ pub fn render_footer<D: DataProvider>(
         );
 
     frame.render_widget(footer, area);
+}
+
+fn get_footer_text<D: DataProvider>(ui_components: &UIComponents, app: &App<D>) -> String {
+    let (edior_mode, multi_select_mode) = (
+        ui_components.editor.is_insert_mode(),
+        ui_components.entries_list.multi_select_mode,
+    );
+    match (edior_mode, multi_select_mode) {
+        (true, false) => get_editor_mode_text(ui_components),
+        (false, true) => get_multi_select_text(ui_components),
+        _ => get_standard_text(ui_components, app),
+    }
 }
 
 fn get_editor_mode_text(ui_components: &UIComponents) -> String {

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -8,7 +8,7 @@ use self::{
     entry_popup::{EntryPopup, EntryPopupInputReturn},
     export_popup::ExportPopup,
     filter_popup::FilterPopup,
-    footer::render_footer,
+    footer::{get_footer_heigh, render_footer},
     fuzz_find::FuzzFindPopup,
     help_popup::{HelpInputInputReturn, HelpPopup},
     msg_box::{MsgBox, MsgBoxActions, MsgBoxType},
@@ -123,9 +123,11 @@ impl<'a, 'b> UIComponents<'a> {
     where
         D: DataProvider,
     {
+        let footer_height = get_footer_heigh(f.size().width, self, app);
+
         let chunks = Layout::default()
             .direction(Direction::Vertical)
-            .constraints([Constraint::Min(2), Constraint::Length(1)].as_ref())
+            .constraints([Constraint::Min(2), Constraint::Length(footer_height)].as_ref())
             .split(f.size());
 
         render_footer(f, chunks[1], self, app);


### PR DESCRIPTION
This PR closes #283 

The height of the main footer will be calculated each time the frame is rendered instead of having it fixed to 1 row height.

This Fix the issue when the text is cut if the footer text is too long for the given terminal space