### PR TITLE
Fixed: App will be redrawn on not handled input too

### DIFF
--- a/src/app/runner.rs
+++ b/src/app/runner.rs
@@ -99,7 +99,11 @@ where
                         ui_components.update_current_entry(&mut app);
                         draw_ui(terminal, &mut app, &mut ui_components)?;
                     }
-                    HandleInputReturnType::NotFound => {}
+                    HandleInputReturnType::NotFound => {
+                        // UI should be drawn even if the input isn't handled in the app logic to
+                        // catch events like resize, Font resize, Mouse activation...
+                        draw_ui(terminal, &mut app, &mut ui_components)?;
+                    }
                     HandleInputReturnType::ExitApp => return Ok(()),
                 };
             }


### PR DESCRIPTION
This PR closes #282 

The bug has been introduced a few days ago when the not handled inputs went ignored and didn't caused the UI to be redrawn anymore. This change didn't consider the environment changes like changing the terminal or the font size or resizing the terminal window.

@orhun  This PR return the redraw call back when the input isn't handled in the app logic

