### PR TITLE
Fixed:  CHANGELOG creation logic; fixes #286

### DIFF
--- a/.github/workflows/changelog-assembly.yml
+++ b/.github/workflows/changelog-assembly.yml
@@ -33,7 +33,7 @@ jobs:
 
       - run: |
           aeruginous comment-changes \
-            -b -d : -f ron -k -o changelog.d/ -S "$(cat .version)"
+            -b -d : -f ron -k -o changelog.d/ -S "v$(cat .version)"
           aeruginous increment-version \
             -v "$(cat .version)" \
             -r ${{ inputs.release }} \


### PR DESCRIPTION
This PR fixes #286.

There was a missing `v` prefix.  Now, the tag should be retrievable.