### PR TITLE
Added: Add Default suggested priority while creating a journal

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,9 @@ The configuration for TUI-Journal can be found in the `config.toml` file located
 Here is a sample of the settings in the `config.toml` file:
 
 ```toml
-backend_type = "Sqlite"   # available options: Json, Sqlite. Default value: Sqlite.
+backend_type = "Sqlite"   # Available options: Json, Sqlite. Default value: Sqlite.
+
+default_journal_priority = 3  # Sets the suggested priority while creating a new journal
 
 [export]
 default_path = "<Absolute_path_to_export_directory>"   # Optional default path to export multiple journals or a single journal's content. Falls back to the current directory if not specified.

--- a/src/app/ui/commands/entries_list_cmd.rs
+++ b/src/app/ui/commands/entries_list_cmd.rs
@@ -107,21 +107,24 @@ pub async fn continue_select_next_entry<'a, D: DataProvider>(
     Ok(HandleInputReturnType::Handled)
 }
 
-pub fn exec_create_entry(ui_components: &mut UIComponents) -> CmdResult {
+pub fn exec_create_entry<D: DataProvider>(
+    ui_components: &mut UIComponents,
+    app: &App<D>,
+) -> CmdResult {
     if ui_components.has_unsaved() {
         ui_components.show_unsaved_msg_box(Some(UICommand::CreateEntry));
     } else {
-        create_entry(ui_components);
+        create_entry(ui_components, app);
     }
 
     Ok(HandleInputReturnType::Handled)
 }
 
 #[inline]
-pub fn create_entry(ui_components: &mut UIComponents) {
+pub fn create_entry<D: DataProvider>(ui_components: &mut UIComponents, app: &App<D>) {
     ui_components
         .popup_stack
-        .push(Popup::Entry(Box::new(EntryPopup::new_entry())));
+        .push(Popup::Entry(Box::new(EntryPopup::new_entry(&app.settings))));
 }
 
 pub async fn continue_create_entry<'a, D: DataProvider>(
@@ -133,9 +136,9 @@ pub async fn continue_create_entry<'a, D: DataProvider>(
         MsgBoxResult::Ok | MsgBoxResult::Cancel => {}
         MsgBoxResult::Yes => {
             exec_save_entry_content(ui_components, app).await?;
-            create_entry(ui_components);
+            create_entry(ui_components, app);
         }
-        MsgBoxResult::No => create_entry(ui_components),
+        MsgBoxResult::No => create_entry(ui_components, app),
     }
 
     Ok(HandleInputReturnType::Handled)

--- a/src/app/ui/commands/mod.rs
+++ b/src/app/ui/commands/mod.rs
@@ -207,7 +207,7 @@ impl UICommand {
             UICommand::CycleFocusedControlBack => exec_cycle_backward(ui_components),
             UICommand::SelectedNextEntry => exec_select_next_entry(ui_components, app),
             UICommand::SelectedPrevEntry => exec_select_prev_entry(ui_components, app),
-            UICommand::CreateEntry => exec_create_entry(ui_components),
+            UICommand::CreateEntry => exec_create_entry(ui_components, app),
             UICommand::EditCurrentEntry => exec_edit_current_entry(ui_components, app),
             UICommand::DeleteCurrentEntry => exec_delete_current_entry(ui_components, app),
             UICommand::StartEditEntryContent => exec_start_edit_content(ui_components),

--- a/src/app/ui/entry_popup/mod.rs
+++ b/src/app/ui/entry_popup/mod.rs
@@ -9,7 +9,10 @@ use ratatui::{
 };
 use tui_textarea::{CursorMove, TextArea};
 
-use crate::app::{keymap::Input, App};
+use crate::{
+    app::{keymap::Input, App},
+    settings::Settings,
+};
 
 use backend::{DataProvider, Entry};
 
@@ -56,7 +59,7 @@ pub enum EntryPopupInputReturn {
 }
 
 impl<'a> EntryPopup<'a> {
-    pub fn new_entry() -> Self {
+    pub fn new_entry(settings: &Settings) -> Self {
         let title_txt = TextArea::default();
 
         let date = Local::now();
@@ -69,7 +72,12 @@ impl<'a> EntryPopup<'a> {
         )]);
 
         let tags_txt = TextArea::default();
-        let priority_txt = TextArea::default();
+
+        let priority_txt = if let Some(priority) = settings.default_journal_priority {
+            TextArea::new(vec![priority.to_string()])
+        } else {
+            TextArea::default()
+        };
 
         Self {
             title_txt,

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -36,6 +36,8 @@ pub struct Settings {
     #[cfg(feature = "sqlite")]
     #[serde(default)]
     pub sqlite_backend: SqliteBackend,
+    #[serde(default)]
+    pub default_journal_priority: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, ValueEnum, Clone, Copy, Default)]
@@ -94,6 +96,7 @@ impl Settings {
             sqlite_backend: _,
             export: _,
             external_editor: _,
+            default_journal_priority: _,
         } = self;
 
         if self.backend_type.is_none() {


### PR DESCRIPTION
This PR closes #291 

It add the setting field `default_journal_priority` to specify the suggested the journal priority while creating a new journal entry