### PR TITLE
Added: CLI Sub-Command to assign priority to journals

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ TUI-Journal is a terminal-based application written in Rust that allows you to w
 - [x]  Edit journals content with external text editor from within the app.
 - [x]  Filter & Search functionalities.
 - [ ]  Customize themes and keybindings.
-- [ ]  Load entries as chunks for better performance.
 
       
 ## Installation
@@ -181,6 +180,7 @@ Usage: tjournal [OPTIONS] [COMMAND]
 Commands:
   print-config  Print the current settings including the paths for the backend files [aliases: pc]
   import-journals  Import journals from the given transfer JSON file to the current back-end file [aliases: imj]
+  assign-priority  Assign priority for all the entires with empty priority field [aliases: ap]
   help          Print this message or the help of the given subcommand(s)
 
 Options:

--- a/backend/src/json.rs
+++ b/backend/src/json.rs
@@ -103,6 +103,19 @@ impl DataProvider for JsonDataProvide {
 
         Ok(EntriesDTO::new(entries))
     }
+
+    async fn assign_priority_to_entries(&self, priority: u32) -> anyhow::Result<()> {
+        let mut entries = self.load_all_entries().await?;
+
+        entries
+            .iter_mut()
+            .filter(|entry| entry.priority.is_none())
+            .for_each(|entry| entry.priority = Some(priority));
+
+        self.write_entries_to_file(&entries).await?;
+
+        Ok(())
+    }
 }
 
 impl JsonDataProvide {

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -36,8 +36,8 @@ pub trait DataProvider {
             "Version mismatches check if there is a need to do a converting to the data"
         );
 
-        for entry_darft in entries_dto.entries {
-            self.add_entry(entry_darft).await?;
+        for entry_draft in entries_dto.entries {
+            self.add_entry(entry_draft).await?;
         }
 
         Ok(())

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -42,6 +42,8 @@ pub trait DataProvider {
 
         Ok(())
     }
+    /// Assigns priority to all entries that don't have a priority assigned to
+    async fn assign_priority_to_entries(&self, priority: u32) -> anyhow::Result<()>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/backend/src/sqlite/mod.rs
+++ b/backend/src/sqlite/mod.rs
@@ -242,7 +242,7 @@ impl DataProvider for SqliteDataProvide {
             .execute(&self.pool)
             .await
             .map_err(|err| {
-                log::error!("Assign priority to entries faild. Error info {err}");
+                log::error!("Assign priority to entries failed. Error info {err}");
 
                 anyhow!(err)
             })?;

--- a/backend/src/sqlite/mod.rs
+++ b/backend/src/sqlite/mod.rs
@@ -229,4 +229,24 @@ impl DataProvider for SqliteDataProvide {
 
         Ok(EntriesDTO::new(entry_drafts))
     }
+
+    async fn assign_priority_to_entries(&self, priority: u32) -> anyhow::Result<()> {
+        let sql = format!(
+            r"UPDATE entries
+            SET priority = '{}'
+            WHERE priority IS NULL;",
+            priority
+        );
+
+        sqlx::query(sql.as_str())
+            .execute(&self.pool)
+            .await
+            .map_err(|err| {
+                log::error!("Assign priority to entries faild. Error info {err}");
+
+                anyhow!(err)
+            })?;
+
+        Ok(())
+    }
 }

--- a/backend/tests/json/mod.rs
+++ b/backend/tests/json/mod.rs
@@ -115,7 +115,7 @@ async fn update_entry() {
 }
 
 #[tokio::test]
-async fn text_export_import() {
+async fn export_import() {
     let temp_file_source = TempFile::new("json_export_source");
     let provider_source = create_provide_with_two_entries(temp_file_source.file_path.clone()).await;
 
@@ -139,4 +139,17 @@ async fn text_export_import() {
     let dto_dist = provider_dist.get_export_object(&created_ids).await.unwrap();
 
     assert_eq!(dto_source, dto_dist);
+}
+
+#[tokio::test]
+async fn assign_priority() {
+    let temp_file = TempFile::new("json_assign_priority");
+    let provider = create_provide_with_two_entries(temp_file.file_path.clone()).await;
+
+    provider.assign_priority_to_entries(3).await.unwrap();
+
+    let entries = provider.load_all_entries().await.unwrap();
+
+    assert_eq!(entries[0].priority, Some(3));
+    assert_eq!(entries[1].priority, Some(1));
 }

--- a/backend/tests/sqlite/mod.rs
+++ b/backend/tests/sqlite/mod.rs
@@ -111,7 +111,7 @@ async fn update_entry() {
 }
 
 #[tokio::test]
-async fn text_export_import() {
+async fn export_import() {
     let provider_source = create_provider_with_two_entries().await;
 
     let created_ids = [1, 2];
@@ -133,4 +133,16 @@ async fn text_export_import() {
     let dto_dist = provider_dist.get_export_object(&created_ids).await.unwrap();
 
     assert_eq!(dto_source, dto_dist);
+}
+
+#[tokio::test]
+async fn assign_priority() {
+    let provider = create_provider_with_two_entries().await;
+
+    provider.assign_priority_to_entries(3).await.unwrap();
+
+    let entries = provider.load_all_entries().await.unwrap();
+
+    assert_eq!(entries[0].priority, Some(3));
+    assert_eq!(entries[1].priority, Some(1));
 }

--- a/backend/tests/sqlite/mod.rs
+++ b/backend/tests/sqlite/mod.rs
@@ -2,7 +2,7 @@ use backend::*;
 use chrono::{TimeZone, Utc};
 
 async fn create_provider_with_two_entries() -> SqliteDataProvide {
-    let provider = create_prvoider().await;
+    let provider = create_provider().await;
 
     let mut entry_draft_1 = EntryDraft::new(
         Utc::now(),
@@ -26,7 +26,7 @@ async fn create_provider_with_two_entries() -> SqliteDataProvide {
 }
 
 #[inline]
-async fn create_prvoider() -> SqliteDataProvide {
+async fn create_provider() -> SqliteDataProvide {
     SqliteDataProvide::create("sqlite::memory:").await.unwrap()
 }
 
@@ -123,7 +123,7 @@ async fn export_import() {
 
     assert_eq!(dto_source.entries.len(), created_ids.len());
 
-    let provider_dist = create_prvoider().await;
+    let provider_dist = create_provider().await;
 
     provider_dist
         .import_entries(dto_source.clone())

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -282,4 +282,13 @@ where
             self.filtered_out_entries.clear();
         }
     }
+
+    /// Assigns priority to all entries that don't have a priority assigned to
+    async fn assign_priority_to_entries(&self, priority: u32) -> anyhow::Result<()> {
+        self.data_provide
+            .assign_priority_to_entries(priority)
+            .await?;
+
+        Ok(())
+    }
 }

--- a/src/app/runner.rs
+++ b/src/app/runner.rs
@@ -128,6 +128,10 @@ async fn exec_pending_cmd<B: Backend, D: DataProvider>(
 
             app.import_entries(file_path).await?;
         }
+        PendingCliCommand::AssignPriority(priority) => {
+            terminal.draw(|f| render_message_centered(f, "Assigning Priority to Journals..."))?;
+            app.assign_priority_to_entries(priority).await?;
+        }
     }
 
     Ok(())

--- a/src/app/runner.rs
+++ b/src/app/runner.rs
@@ -91,7 +91,7 @@ where
 
     let mut input_stream = EventStream::new();
     while let Some(event) = input_stream.next().await {
-        let event = event.context("Error gettig input stream")?;
+        let event = event.context("Error getting input stream")?;
         match handle_input(event, &mut app, &mut ui_components).await {
             Ok(result) => {
                 match result {
@@ -123,7 +123,7 @@ async fn exec_pending_cmd<B: Backend, D: DataProvider>(
     pending_cmd: PendingCliCommand,
 ) -> anyhow::Result<()> {
     match pending_cmd {
-        PendingCliCommand::ImportJorunals(file_path) => {
+        PendingCliCommand::ImportJournals(file_path) => {
             terminal.draw(|f| render_message_centered(f, "Importing journals..."))?;
 
             app.import_entries(file_path).await?;

--- a/src/app/test/mock.rs
+++ b/src/app/test/mock.rs
@@ -101,4 +101,8 @@ impl DataProvider for MockDataProvider {
 
         Ok(())
     }
+
+    async fn assign_priority_to_entries(&self, _priority: u32) -> anyhow::Result<()> {
+        unimplemented!("There are not tests for assigning priority on the app level");
+    }
 }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -29,7 +29,7 @@ pub enum CliCommand {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PendingCliCommand {
-    ImportJorunals(PathBuf),
+    ImportJournals(PathBuf),
     AssignPriority(u32),
 }
 
@@ -38,7 +38,7 @@ impl CliCommand {
         match self {
             CliCommand::PrintConfig => exec_print_config(settings).await,
             CliCommand::ImportJournals { file_path: path } => Ok(CliResult::PendingCommand(
-                PendingCliCommand::ImportJorunals(path),
+                PendingCliCommand::ImportJournals(path),
             )),
             CliCommand::AssignPriority { priority } => Ok(CliResult::PendingCommand(
                 PendingCliCommand::AssignPriority(priority),

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -18,11 +18,19 @@ pub enum CliCommand {
         #[arg(short = 'p', long = "path", required = true, value_name = "FILE PATH")]
         file_path: PathBuf,
     },
+    /// Assign priority for all the entires with empty priority field
+    #[clap(visible_alias = "ap")]
+    AssignPriority {
+        /// Priority value (Positive number)
+        #[arg(required = true, value_name = "PRIORITY", index = 1)]
+        priority: u32,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PendingCliCommand {
     ImportJorunals(PathBuf),
+    AssignPriority(u32),
 }
 
 impl CliCommand {
@@ -31,6 +39,9 @@ impl CliCommand {
             CliCommand::PrintConfig => exec_print_config(settings).await,
             CliCommand::ImportJournals { file_path: path } => Ok(CliResult::PendingCommand(
                 PendingCliCommand::ImportJorunals(path),
+            )),
+            CliCommand::AssignPriority { priority } => Ok(CliResult::PendingCommand(
+                PendingCliCommand::AssignPriority(priority),
             )),
         }
     }


### PR DESCRIPTION
This PR closes #295 

It adds the CLI command `assign-priority` which takes the wanted priority is argument and assign it to all journals which doesn't have a priority assigned to them. 

This is helpful for existing journals if the user wants to assign a priority to all the existing journals