### PR TITLE
Added: Go to Top/Bottom & Page Up/Down Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ default_journal_priority = 3  # Sets the suggested priority while creating a new
 [export]
 default_path = "<Absolute_path_to_export_directory>"   # Optional default path to export multiple journals or a single journal's content. Falls back to the current directory if not specified.
 show_confirmation = true   # Show confirmation after successful export.
+scroll_per_page = 5    # Sets how many journals will be scrolled using Page-Up and Page-Down command
 
 [external_editor]
 # Set the external terminal editor to use from within the app.

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -209,6 +209,22 @@ pub fn get_entries_list_keymaps() -> Vec<Keymap> {
             Input::new(KeyCode::Char('o'), KeyModifiers::NONE),
             UICommand::ShowSortOptions,
         ),
+        Keymap::new(
+            Input::new(KeyCode::Home, KeyModifiers::NONE),
+            UICommand::GoToTopEntry,
+        ),
+        Keymap::new(
+            Input::new(KeyCode::End, KeyModifiers::NONE),
+            UICommand::GoToBottomEntry,
+        ),
+        Keymap::new(
+            Input::new(KeyCode::PageUp, KeyModifiers::NONE),
+            UICommand::PageUpEntries,
+        ),
+        Keymap::new(
+            Input::new(KeyCode::PageDown, KeyModifiers::NONE),
+            UICommand::PageDownEntries,
+        ),
     ]
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -65,7 +65,7 @@ where
     }
 
     /// Get entries that meet the filter criteria if any otherwise it returns all entries
-    pub fn get_active_entries(&self) -> impl Iterator<Item = &Entry> {
+    pub fn get_active_entries(&self) -> impl DoubleEndedIterator<Item = &Entry> {
         self.entries
             .iter()
             .filter(|entry| !self.filtered_out_entries.contains(&entry.id))

--- a/src/app/ui/commands/entries_list_cmd.rs
+++ b/src/app/ui/commands/entries_list_cmd.rs
@@ -478,3 +478,19 @@ pub async fn continue_show_sort_options<'a, D: DataProvider>(
 
     Ok(HandleInputReturnType::Handled)
 }
+
+pub fn go_to_top_entry<D: DataProvider>(ui_components: &mut UIComponents, app: &mut App<D>) {
+    todo!()
+}
+
+pub fn go_to_bottom_entry<D: DataProvider>(ui_components: &mut UIComponents, app: &mut App<D>) {
+    todo!()
+}
+
+pub fn page_up_entries<D: DataProvider>(ui_components: &mut UIComponents, app: &mut App<D>) {
+    todo!()
+}
+
+pub fn page_down_entries<D: DataProvider>(ui_components: &mut UIComponents, app: &mut App<D>) {
+    todo!()
+}

--- a/src/app/ui/commands/entries_list_cmd.rs
+++ b/src/app/ui/commands/entries_list_cmd.rs
@@ -505,13 +505,13 @@ pub fn go_to_bottom_entry<D: DataProvider>(ui_components: &mut UIComponents, app
 }
 
 pub fn page_up_entries<D: DataProvider>(ui_components: &mut UIComponents, app: &mut App<D>) {
-    //TODO: get step from app settings
-    let step = 5;
+    let step = app.settings.get_scroll_per_page();
 
     select_prev_entry(step, ui_components, app);
 }
 
 pub fn page_down_entries<D: DataProvider>(ui_components: &mut UIComponents, app: &mut App<D>) {
-    let step = 5;
+    let step = app.settings.get_scroll_per_page();
+
     select_next_entry(step, ui_components, app);
 }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -22,6 +22,8 @@ pub mod sqlite_backend;
 mod export;
 mod external_editor;
 
+const DEFAULT_SCROLL_PER_PAGE: usize = 5;
+
 #[derive(Debug, Deserialize, Serialize, Default)]
 pub struct Settings {
     #[serde(default)]
@@ -38,6 +40,8 @@ pub struct Settings {
     pub sqlite_backend: SqliteBackend,
     #[serde(default)]
     pub default_journal_priority: Option<u32>,
+    #[serde(default)]
+    pub scroll_per_page: Option<usize>,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, ValueEnum, Clone, Copy, Default)]
@@ -97,6 +101,7 @@ impl Settings {
             export: _,
             external_editor: _,
             default_journal_priority: _,
+            scroll_per_page: _,
         } = self;
 
         if self.backend_type.is_none() {
@@ -113,7 +118,15 @@ impl Settings {
             self.sqlite_backend.file_path = Some(get_default_sqlite_path()?)
         }
 
+        if self.scroll_per_page.is_none() {
+            self.scroll_per_page = Some(DEFAULT_SCROLL_PER_PAGE);
+        }
+
         Ok(())
+    }
+
+    pub fn get_scroll_per_page(&self) -> usize {
+        self.scroll_per_page.unwrap_or(DEFAULT_SCROLL_PER_PAGE)
     }
 }
 


### PR DESCRIPTION
This PR closes #301 

It adds the following commands:
- Go to top entry `Home`
- Go to bottom entry `End`
- Page Up/Down through journals using `PageUp` and `PageDown` with default step of 5

Step for Page Up/Down is configurable in the app settings