### PR TITLE
Fixed:  Aeruginous:  migrate from deprecated comment-changes option ``-T``

### DIFF
--- a/.github/workflows/changelog-assembly.yml
+++ b/.github/workflows/changelog-assembly.yml
@@ -36,7 +36,7 @@ jobs:
 
       - run: |
           aeruginous comment-changes \
-            -b -d : -f ron -k -o changelog.d/ -T "v$(cat .version)"
+            -b -d : -f ron -k -o changelog.d/ -@ "v$(cat .version)"
           aeruginous increment-version \
             -v "$(cat .version)" \
             -r ${{ inputs.release }} \


### PR DESCRIPTION
#288 has shown that the design of the stop condition specification for comment-changes was counter-intuitive.  If not even I as the maintainer can tell the options of my own application apart, my design decisions were obviously wrong.  Thus, I implemented a combination option for comment-changes, ``-@``, which does not care for the actual type of the stop condition -- all valid commit numbers, tags, and branch names are allowed.  Furthermore, the number of possible stop conditions is not restricted to two, anymore -- you are now allowed to define an arbitrary number whereas the first met condition will stop the commit message harvesting.

Due to this new option, ``-S`` and ``-T`` are now superseded because ``-@`` combines their functionality.  Thus, they have been marked deprecated and will be removed in the next major release; see https://github.com/kevinmatthes/aeruginous-rs/discussions/1118.

---

This PR migrates the calls to Aeruginous to the new version 3.7.4 to benefit from the latest changes; see https://github.com/kevinmatthes/aeruginous-rs/discussions/1123.