### PR TITLE
Added: Rust minimum supported version to cargo manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/ammarabouzor/tui-journal"
 readme = "README.md"
 categories = ["command-line-utilities"]
 keywords = ["tui", "terminal-app", "journal", "cli", "ui"]
+rust-version = "1.75.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
Related to #309 

This PR adds rust minimum supported version to `cargo.toml`, since upgrading to the version 1.75 for the early adaptation for native support to async traits caused some confusion

