### PR TITLE
Enhancement: Remove explicit inline annotations

### DIFF
--- a/src/app/ui/commands/editor_cmd.rs
+++ b/src/app/ui/commands/editor_cmd.rs
@@ -55,7 +55,6 @@ pub fn continue_discard_content<D: DataProvider>(
     Ok(HandleInputReturnType::Handled)
 }
 
-#[inline]
 pub fn discard_current_content<D: DataProvider>(
     ui_components: &mut UIComponents,
     app: &mut App<D>,

--- a/src/app/ui/commands/entries_list_cmd.rs
+++ b/src/app/ui/commands/entries_list_cmd.rs
@@ -24,7 +24,6 @@ pub fn exec_select_prev_entry<D: DataProvider>(
     Ok(HandleInputReturnType::Handled)
 }
 
-#[inline]
 fn select_prev_entry<D: DataProvider>(
     step: usize,
     ui_components: &mut UIComponents,
@@ -76,7 +75,6 @@ pub fn exec_select_next_entry<D: DataProvider>(
     Ok(HandleInputReturnType::Handled)
 }
 
-#[inline]
 fn select_next_entry<D: DataProvider>(
     step: usize,
     ui_components: &mut UIComponents,
@@ -129,7 +127,6 @@ pub fn exec_create_entry<D: DataProvider>(
     Ok(HandleInputReturnType::Handled)
 }
 
-#[inline]
 pub fn create_entry<D: DataProvider>(ui_components: &mut UIComponents, app: &App<D>) {
     ui_components
         .popup_stack
@@ -166,7 +163,6 @@ pub fn exec_edit_current_entry<D: DataProvider>(
     Ok(HandleInputReturnType::Handled)
 }
 
-#[inline]
 fn edit_current_entry<D: DataProvider>(ui_components: &mut UIComponents, app: &mut App<D>) {
     if let Some(entry) = app.get_current_entry() {
         ui_components
@@ -243,7 +239,6 @@ pub fn exec_export_entry_content<D: DataProvider>(
     Ok(HandleInputReturnType::Handled)
 }
 
-#[inline]
 pub fn export_entry_content<D: DataProvider>(ui_components: &mut UIComponents, app: &App<D>) {
     if let Some(entry) = app.get_current_entry() {
         match ExportPopup::create_entry_content(entry, app) {
@@ -360,7 +355,6 @@ pub fn exec_show_filter<D: DataProvider>(
     Ok(HandleInputReturnType::Handled)
 }
 
-#[inline]
 fn show_filter<D: DataProvider>(ui_components: &mut UIComponents, app: &mut App<D>) {
     let tags = app.get_all_tags();
     ui_components
@@ -410,7 +404,6 @@ pub fn exec_show_fuzzy_find<D: DataProvider>(
     Ok(HandleInputReturnType::Handled)
 }
 
-#[inline]
 fn show_fuzzy_find<D: DataProvider>(ui_components: &mut UIComponents, app: &mut App<D>) {
     let entries: HashMap<u32, String> = app
         .get_active_entries()

--- a/src/app/ui/commands/global_cmd.rs
+++ b/src/app/ui/commands/global_cmd.rs
@@ -88,7 +88,6 @@ pub async fn exec_reload_all<'a, D: DataProvider>(
     Ok(HandleInputReturnType::Handled)
 }
 
-#[inline]
 async fn reload_all<'a, D: DataProvider>(
     ui_components: &mut UIComponents<'a>,
     app: &mut App<D>,

--- a/src/app/ui/commands/multi_select_cmd.rs
+++ b/src/app/ui/commands/multi_select_cmd.rs
@@ -74,7 +74,6 @@ pub fn exec_toggle_selected<D: DataProvider>(app: &mut App<D>) -> CmdResult {
     Ok(HandleInputReturnType::Handled)
 }
 
-#[inline]
 fn toggle_entry_selection<D: DataProvider>(entry_id: u32, app: &mut App<D>) {
     if !app.selected_entries.insert(entry_id) {
         // entry was selected, then remove it

--- a/src/app/ui/editor/mod.rs
+++ b/src/app/ui/editor/mod.rs
@@ -472,7 +472,6 @@ impl<'a> Editor<'a> {
     }
 }
 
-#[inline]
 fn is_default_navigation(input: &Input) -> bool {
     let has_control = input.modifiers.contains(KeyModifiers::CONTROL);
     let has_alt = input.modifiers.contains(KeyModifiers::ALT);

--- a/src/app/ui/entries_list/mod.rs
+++ b/src/app/ui/entries_list/mod.rs
@@ -243,7 +243,6 @@ impl<'a> EntriesList {
         frame.render_widget(place_holder, area);
     }
 
-    #[inline]
     fn get_list_block(&self, has_filter: bool) -> Block<'a> {
         let title = match (self.multi_select_mode, has_filter) {
             (true, true) => "Journals - Multi-Select - Filtered",

--- a/src/app/ui/entry_popup/mod.rs
+++ b/src/app/ui/entry_popup/mod.rs
@@ -495,12 +495,10 @@ impl<'a> EntryPopup<'a> {
     }
 }
 
-#[inline]
 fn tags_to_text(tags: &[String]) -> String {
     tags.join(", ")
 }
 
-#[inline]
 fn text_to_tags(text: &str) -> Vec<String> {
     text.split_terminator(',')
         .map(|tag| String::from(tag.trim()))

--- a/src/app/ui/entry_popup/tags.rs
+++ b/src/app/ui/entry_popup/tags.rs
@@ -159,7 +159,6 @@ impl TagsPopup {
         }
     }
 
-    #[inline]
     fn cycle_next_tag(&mut self) -> TagsPopupReturn {
         if !self.tags.is_empty() {
             let last_index = self.tags.len() - 1;
@@ -175,7 +174,6 @@ impl TagsPopup {
         TagsPopupReturn::Keep
     }
 
-    #[inline]
     fn cycle_prev_tag(&mut self) -> TagsPopupReturn {
         if !self.tags.is_empty() {
             let last_index = self.tags.len() - 1;
@@ -191,7 +189,6 @@ impl TagsPopup {
         TagsPopupReturn::Keep
     }
 
-    #[inline]
     fn toggle_selected(&mut self) -> TagsPopupReturn {
         if let Some(idx) = self.state.selected() {
             let tag = self

--- a/src/app/ui/filter_popup/mod.rs
+++ b/src/app/ui/filter_popup/mod.rs
@@ -133,7 +133,6 @@ impl<'a> FilterPopup<'a> {
         self.render_footer(frame, chunks[5]);
     }
 
-    #[inline]
     fn render_relations(&mut self, frame: &mut Frame, area: Rect) {
         let relation_text = match self.relation {
             CriteriaRelation::And => "Journals must meet all criteria",
@@ -152,7 +151,6 @@ impl<'a> FilterPopup<'a> {
         frame.render_widget(relation, area);
     }
 
-    #[inline]
     fn render_text_boxes(
         &mut self,
         frame: &mut Frame,
@@ -220,7 +218,6 @@ impl<'a> FilterPopup<'a> {
         frame.render_widget(self.priority_txt.widget(), priority_area);
     }
 
-    #[inline]
     fn render_tags_list(&mut self, frame: &mut Frame, area: Rect) {
         let items: Vec<ListItem> = self
             .tags
@@ -251,7 +248,6 @@ impl<'a> FilterPopup<'a> {
         frame.render_stateful_widget(list, area, &mut self.tags_state);
     }
 
-    #[inline]
     fn render_tags_place_holder(&mut self, frame: &mut Frame, area: Rect) {
         let place_holder_text = String::from("\nNo journals with tags provided");
 
@@ -263,7 +259,6 @@ impl<'a> FilterPopup<'a> {
         frame.render_widget(place_holder, area);
     }
 
-    #[inline]
     fn get_list_block<'b>(&self) -> Block<'b> {
         let style = match self.active_control {
             FilterControl::TagsList => Style::default().fg(ACTIVE_BORDER_COLOR),
@@ -276,7 +271,6 @@ impl<'a> FilterPopup<'a> {
             .style(style)
     }
 
-    #[inline]
     fn render_footer(&mut self, frame: &mut Frame, area: Rect) {
         let footer = Paragraph::new(FOOTER_TEXT)
             .alignment(Alignment::Center)
@@ -359,7 +353,6 @@ impl<'a> FilterPopup<'a> {
         FilterPopupReturn::KeepPopup
     }
 
-    #[inline]
     fn cycle_next_tag(&mut self) {
         if self.tags.is_empty() {
             return;
@@ -375,7 +368,6 @@ impl<'a> FilterPopup<'a> {
         self.tags_state.select(Some(new_index));
     }
 
-    #[inline]
     fn cycle_prev_tag(&mut self) {
         if self.tags.is_empty() {
             return;
@@ -391,7 +383,6 @@ impl<'a> FilterPopup<'a> {
         self.tags_state.select(Some(new_index));
     }
 
-    #[inline]
     fn change_relation(&mut self) {
         self.relation = match self.relation {
             CriteriaRelation::And => CriteriaRelation::Or,
@@ -399,7 +390,6 @@ impl<'a> FilterPopup<'a> {
         }
     }
 
-    #[inline]
     fn toggle_selected(&mut self) {
         if let Some(idx) = self.tags_state.selected() {
             let tag = self

--- a/src/app/ui/fuzz_find/mod.rs
+++ b/src/app/ui/fuzz_find/mod.rs
@@ -97,7 +97,6 @@ impl<'a> FuzzFindPopup<'a> {
         self.render_footer(frame, chunks[2]);
     }
 
-    #[inline]
     fn render_entries_list(&mut self, frame: &mut Frame, area: Rect) {
         let items: Vec<ListItem> = self
             .filtered_entries
@@ -141,7 +140,6 @@ impl<'a> FuzzFindPopup<'a> {
         frame.render_stateful_widget(list, area, &mut self.list_state);
     }
 
-    #[inline]
     fn render_footer(&mut self, frame: &mut Frame, area: Rect) {
         let footer = Paragraph::new(FOOTER_TEXT)
             .alignment(Alignment::Center)
@@ -182,7 +180,6 @@ impl<'a> FuzzFindPopup<'a> {
         FuzzFindReturn::SelectEntry(selected_id)
     }
 
-    #[inline]
     pub fn cycle_next_entry(&mut self) {
         if self.filtered_entries.is_empty() {
             return;
@@ -195,7 +192,6 @@ impl<'a> FuzzFindPopup<'a> {
         self.list_state.select(Some(new_index));
     }
 
-    #[inline]
     pub fn cycle_prev_entry(&mut self) {
         if self.filtered_entries.is_empty() {
             return;

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -331,7 +331,6 @@ impl<'a, 'b> UIComponents<'a> {
         }
     }
 
-    #[inline]
     async fn handle_export_popup_return<D: DataProvider>(
         &mut self,
         path: PathBuf,

--- a/src/app/ui/sort_popup/mod.rs
+++ b/src/app/ui/sort_popup/mod.rs
@@ -196,7 +196,6 @@ impl SortPopup {
         frame.render_stateful_widget(list, area, &mut self.applied_state);
     }
 
-    #[inline]
     fn render_footer(&self, footer_text: String, frame: &mut Frame, area: Rect) {
         let footer = Paragraph::new(footer_text)
             .alignment(Alignment::Center)
@@ -206,7 +205,6 @@ impl SortPopup {
         frame.render_widget(footer, area);
     }
 
-    #[inline]
     fn get_list_highlight_style(is_focused: bool) -> Style {
         let base_style = Style::default().fg(Color::Black);
         if is_focused {
@@ -316,7 +314,6 @@ impl SortPopup {
         }
     }
 
-    #[inline]
     fn validate(&mut self) {
         self.is_valid = !self.applied_criteria.is_empty();
     }


### PR DESCRIPTION
Let the compiler decide where to inline the functions in where the performance not critical, which saved 1 MB from the binary size.