### PR TITLE
Fixed: Change Help popup shortcut on windows

### DIFF
--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -96,8 +96,15 @@ pub(crate) fn get_global_keymaps() -> Vec<Keymap> {
             Input::new(KeyCode::Char('q'), KeyModifiers::NONE),
             UICommand::Quit,
         ),
+        // Char 'h' isn't recognized on windows
+        #[cfg(not(target_os = "windows"))]
         Keymap::new(
             Input::new(KeyCode::Char('?'), KeyModifiers::NONE),
+            UICommand::ShowHelp,
+        ),
+        #[cfg(target_os = "windows")]
+        Keymap::new(
+            Input::new(KeyCode::Char('h'), KeyModifiers::NONE),
             UICommand::ShowHelp,
         ),
         Keymap::new(
@@ -339,8 +346,15 @@ pub fn get_multi_select_keymaps() -> Vec<Keymap> {
             Input::new(KeyCode::Char('>'), KeyModifiers::NONE),
             UICommand::MulSelExportEntries,
         ),
+        // Char 'h' isn't recognized on windows
+        #[cfg(not(target_os = "windows"))]
         Keymap::new(
             Input::new(KeyCode::Char('?'), KeyModifiers::NONE),
+            UICommand::ShowHelp,
+        ),
+        #[cfg(target_os = "windows")]
+        Keymap::new(
+            Input::new(KeyCode::Char('h'), KeyModifiers::NONE),
             UICommand::ShowHelp,
         ),
     ]

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -96,7 +96,7 @@ pub(crate) fn get_global_keymaps() -> Vec<Keymap> {
             Input::new(KeyCode::Char('q'), KeyModifiers::NONE),
             UICommand::Quit,
         ),
-        // Char 'h' isn't recognized on windows
+        // Char '?' isn't recognized on windows
         #[cfg(not(target_os = "windows"))]
         Keymap::new(
             Input::new(KeyCode::Char('?'), KeyModifiers::NONE),
@@ -346,7 +346,7 @@ pub fn get_multi_select_keymaps() -> Vec<Keymap> {
             Input::new(KeyCode::Char('>'), KeyModifiers::NONE),
             UICommand::MulSelExportEntries,
         ),
-        // Char 'h' isn't recognized on windows
+        // Char '?' isn't recognized on windows
         #[cfg(not(target_os = "windows"))]
         Keymap::new(
             Input::new(KeyCode::Char('?'), KeyModifiers::NONE),


### PR DESCRIPTION
This PR closes #319 

It seems that the shortcut char '?' isn't recognized on Windows and the simplest solution is to change it to the char 'h' on Windows only since it did never work there.