### PR TITLE
Fixed: Specify arm target on mac build and release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,10 @@ clippy:
 build-release:
 	cargo build --release
 
-release-mac: build-release
+build-release_mac_arm:
+	cargo build --release --target=aarch64-apple-darwin
+
+release-mac: build-release_mac_arm
 	strip target/release/tjournal
 	otool -L target/release/tjournal
 	mkdir -p release

--- a/src/app/ui/footer.rs
+++ b/src/app/ui/footer.rs
@@ -145,7 +145,7 @@ fn get_multi_select_text(ui_components: &UIComponents) -> String {
         .filter(|keymap| keymap.command == UICommand::ShowHelp)
         .collect();
 
-    let parts = vec![get_keymap_text(leave_keymap), get_keymap_text(help_keymap)];
+    let parts = [get_keymap_text(leave_keymap), get_keymap_text(help_keymap)];
 
     parts.join(SEPARATOR)
 }


### PR DESCRIPTION
This PR closes #363 

It adds a new build job to the makefile to specify the arm target for builds with MacOS, then it uses this build job for creating the binaries for release on mac