### PR TITLE
Fix release on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build-release:
 build-release_mac_arm:
 	cargo build --release --target=aarch64-apple-darwin
 
-release-mac: build-release_mac_arm
+release-mac: build-release
 	strip target/release/tjournal
 	otool -L target/release/tjournal
 	mkdir -p release


### PR DESCRIPTION
GitHub defaults to MacOS architecture now and there is no need to specify it anymore