### PR TITLE
Remove Editor-Mode check when copying to OS

### DIFF
--- a/src/app/ui/editor/mod.rs
+++ b/src/app/ui/editor/mod.rs
@@ -437,10 +437,6 @@ impl<'a> Editor<'a> {
     }
 
     pub fn get_selected_text(&mut self, operation: ClipboardOperation) -> anyhow::Result<String> {
-        if !self.is_visual_mode() {
-            bail!("Editor isn't in visual mode");
-        }
-
         match operation {
             ClipboardOperation::Copy => self.text_area.copy(),
             ClipboardOperation::Cut => {


### PR DESCRIPTION
This PR closes #386 

It removes the check that the editor must be in visual mode when copying to OS clipboard. 

This Check was there because of the false assumption that we can't select text outside of the visual mode but since we can select text via Shift+Arrow in all editor modes then copying to OS should be supported in all editor modes as well