### PR TITLE
Added: Optionally Sync Clipboard between Built-in Editor and the Operating System

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ TUI-Journal is a terminal-based application written in Rust that allows you to w
 - Export and Import journals between different back-end files.
 - Export the current journal's content to a predefined export path or the current directory 
 - Transfer text between the built-in editor and the system clipboard using Cut, Copy, and Paste.
+- Optionally sync the clipboard between the built-in editor and the operating system, with vim and emacs keybindings.
 - Sorting and full-screen preferences in the App State will be retained.
 - See the keybindings from inside the app
 - Cross-platform compatibility (Windows, macOS, Linux, NetBSD).
@@ -209,6 +210,8 @@ backend_type = "Sqlite"   # Available options: Json, Sqlite. Default value: Sqli
 default_journal_priority = 3  # Sets the suggested priority while creating a new journal
 
 scroll_per_page = 5  # Sets how many journals will be scrolled when using page up/down commands
+
+sync_os_clipboard = false  # Syncs editor clipboard actions with operating system clipboard 
 
 [export]
 default_path = "<Absolute_path_to_export_directory>"   # Optional default path to export multiple journals or a single journal's content. Falls back to the current directory if not specified.

--- a/src/app/ui/commands/editor_cmd.rs
+++ b/src/app/ui/commands/editor_cmd.rs
@@ -1,7 +1,5 @@
 use crate::app::{ui::*, App, HandleInputReturnType, UIComponents};
 
-use anyhow::anyhow;
-use arboard::Clipboard;
 use backend::DataProvider;
 
 use super::{ClipboardOperation, CmdResult};
@@ -77,41 +75,19 @@ pub fn exec_toggle_editor_visual_mode(ui_components: &mut UIComponents) -> CmdRe
 }
 
 pub fn exec_copy_os_clipboard(ui_components: &mut UIComponents) -> CmdResult {
-    send_from_editor_to_os_clipboard(ui_components, ClipboardOperation::Copy)
-}
-
-fn send_from_editor_to_os_clipboard(
-    ui_components: &mut UIComponents,
-    operation: ClipboardOperation,
-) -> CmdResult {
-    let selected_text = ui_components.editor.get_selected_text(operation)?;
-
-    let mut clipboard = Clipboard::new().map_err(map_clipboard_error)?;
-
-    clipboard
-        .set_text(selected_text)
-        .map_err(map_clipboard_error)?;
-
-    Ok(HandleInputReturnType::Handled)
-}
-
-fn map_clipboard_error(err: arboard::Error) -> anyhow::Error {
-    anyhow!(
-        "Error while communicating with the operation system clipboard.\nError Details: {}",
-        err.to_string()
-    )
+    ui_components
+        .editor
+        .exec_os_clipboard(ClipboardOperation::Copy)
 }
 
 pub fn exec_cut_os_clipboard(ui_components: &mut UIComponents) -> CmdResult {
-    send_from_editor_to_os_clipboard(ui_components, ClipboardOperation::Cut)
+    ui_components
+        .editor
+        .exec_os_clipboard(ClipboardOperation::Cut)
 }
 
 pub fn exec_paste_os_clipboard(ui_components: &mut UIComponents) -> CmdResult {
-    let mut clipboard = Clipboard::new().map_err(map_clipboard_error)?;
-
-    let content = clipboard.get_text().map_err(map_clipboard_error)?;
-
-    ui_components.editor.paste_text(&content)?;
-
-    Ok(HandleInputReturnType::Handled)
+    ui_components
+        .editor
+        .exec_os_clipboard(ClipboardOperation::Paste)
 }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -42,6 +42,8 @@ pub struct Settings {
     pub default_journal_priority: Option<u32>,
     #[serde(default)]
     pub scroll_per_page: Option<usize>,
+    #[serde(default)]
+    pub sync_os_clipboard: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, ValueEnum, Clone, Copy, Default)]
@@ -102,6 +104,7 @@ impl Settings {
             external_editor: _,
             default_journal_priority: _,
             scroll_per_page: _,
+            sync_os_clipboard: _,
         } = self;
 
         if self.backend_type.is_none() {


### PR DESCRIPTION
This PR closes #387 

It add the option `sync_os_clipboard` in configuration to enable syncing the clipboard between the built-in editor and the operating system. 
This works with vim keybindings in visual mode and with emacs keybindings in edit mode