### PR TITLE
fix(help): Corrects number of modes and uppercase for editor and Vim

### DIFF
--- a/src/app/ui/help_popup/mod.rs
+++ b/src/app/ui/help_popup/mod.rs
@@ -32,10 +32,10 @@ const MARGIN: u16 = 8;
 
 const TAB_LETTER_HIGHLIGHT_COLOR: Color = Color::LightGreen;
 
-const EDITOR_HINT_TEXT: &str = r"The Editor has two modes:
- - Normal-Mode: In this mode VIM keybindings are used to navigate the text and to enter edit mode via (i, I, a , A, o, O).
+const EDITOR_HINT_TEXT: &str = r"The editor has three modes:
+ - Normal-Mode: In this mode Vim keybindings are used to navigate the text and to enter edit mode via (i, I, a , A, o, O).
  - Edit-Mode: In this mode Emacs keybindings are used to edit and navigate the text.
- - Visual-Mode: Like the visual mode in VIM to select, delete and yank text with extra vim keybindings (d, y, c)";
+ - Visual-Mode: Like the visual mode in Vim to select, delete and yank text with extra vim keybindings (d, y, c)";
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum KeybindingsTabs {


### PR DESCRIPTION
* Corrects the number of modes to three (Normal-Mode, Edit-Mode and Visual-Mode).
* Corrects some unneeded uppercase characters for editor and Vim words.