### PR TITLE
feat: support toggling tag filter

### DIFF
--- a/src/app/filter/criterion.rs
+++ b/src/app/filter/criterion.rs
@@ -1,6 +1,6 @@
 use backend::Entry;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum FilterCriterion {
     Tag(String),
     Title(String),

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -149,7 +149,7 @@ pub(crate) fn get_global_keymaps() -> Vec<Keymap> {
         ),
         Keymap::new(
             Input::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
-            UICommand::ToggleTagFilter,
+            UICommand::CycleTagFilter,
         ),
         Keymap::new(
             Input::new(KeyCode::Char('u'), KeyModifiers::NONE),

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -148,6 +148,10 @@ pub(crate) fn get_global_keymaps() -> Vec<Keymap> {
             UICommand::ToggleFullScreenMode,
         ),
         Keymap::new(
+            Input::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
+            UICommand::ToggleTagFilter,
+        ),
+        Keymap::new(
             Input::new(KeyCode::Char('u'), KeyModifiers::NONE),
             UICommand::Undo,
         ),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -418,6 +418,31 @@ where
             .and_then(|c| c.get_tag_color(tag))
     }
 
+    pub fn cycle_tags_in_filter(&mut self) {
+        let tags = self.get_all_tags();
+        let tag_filter = self.filter.as_ref().and_then(|f| {
+            let filter = &f.criteria;
+            tags.iter()
+                .position(|tag| {
+                    filter
+                        .iter()
+                        .any(|v| v == &FilterCriterion::Tag(tag.to_string()))
+                })
+                .and_then(|index| tags.get(index + 1))
+                .map(|tag| FilterCriterion::Tag(tag.to_string()))
+        });
+
+        if let Some(filter) = tag_filter.or(tags
+            .first()
+            .map(|tag| FilterCriterion::Tag(tag.to_string())))
+        {
+            self.apply_filter(Some(Filter {
+                criteria: vec![filter],
+                ..Default::default()
+            }));
+        }
+    }
+
     /// Assigns priority to all entries that don't have a priority assigned to
     async fn assign_priority_to_entries(&self, priority: u32) -> anyhow::Result<()> {
         self.data_provide

--- a/src/app/ui/commands/entries_list_cmd.rs
+++ b/src/app/ui/commands/entries_list_cmd.rs
@@ -1,11 +1,6 @@
 use std::{collections::HashMap, env};
 
-use crate::app::{
-    external_editor,
-    filter::{Filter, FilterCriterion},
-    ui::*,
-    App, UIComponents,
-};
+use crate::app::{external_editor, ui::*, App, UIComponents};
 
 use backend::DataProvider;
 
@@ -397,27 +392,7 @@ pub fn exec_reset_filter<D: DataProvider>(app: &mut App<D>) -> CmdResult {
 }
 
 pub fn exec_toggle_tag_filter<D: DataProvider>(app: &mut App<D>) -> CmdResult {
-    let tags = app.get_all_tags();
-    let first_tag_filter = tags
-        .first()
-        .map(|tag| FilterCriterion::Tag(tag.to_string()));
-
-    let tag_filter = app.filter.as_ref().and_then(|f| {
-        let filter = &f.criteria;
-        tags.iter()
-            .position(|tag| {
-                filter
-                    .iter()
-                    .any(|v| v == &FilterCriterion::Tag(tag.to_string()))
-            })
-            .and_then(|index| tags.get(index + 1))
-            .map(|tag| FilterCriterion::Tag(tag.to_string()))
-    });
-
-    app.apply_filter(Some(Filter {
-        criteria: vec![tag_filter.or(first_tag_filter).unwrap()],
-        ..Default::default()
-    }));
+    app.cycle_tags_in_filter();
 
     Ok(HandleInputReturnType::Handled)
 }

--- a/src/app/ui/commands/mod.rs
+++ b/src/app/ui/commands/mod.rs
@@ -176,7 +176,7 @@ impl UICommand {
                 "Reset the applied filter on journals",
             ),
             UICommand::CycleTagFilter => CommandInfo::new(
-                "Toggle Tag Filter",
+                "Cycle Tag Filter",
                 "Cycle through the tag filters",
             ),
             UICommand::ShowFuzzyFind => CommandInfo::new(

--- a/src/app/ui/commands/mod.rs
+++ b/src/app/ui/commands/mod.rs
@@ -53,7 +53,7 @@ pub enum UICommand {
     MulSelExportEntries,
     ShowFilter,
     ResetFilter,
-    ToggleTagFilter,
+    CycleTagFilter,
     ShowFuzzyFind,
     ToggleEditorVisualMode,
     ToggleFullScreenMode,
@@ -175,7 +175,7 @@ impl UICommand {
                 "Reset filter",
                 "Reset the applied filter on journals",
             ),
-            UICommand::ToggleTagFilter => CommandInfo::new(
+            UICommand::CycleTagFilter => CommandInfo::new(
                 "Toggle Tag Filter",
                 "Cycle through the tag filters",
             ),
@@ -263,7 +263,7 @@ impl UICommand {
             UICommand::MulSelExportEntries => exec_export_selected_entries(ui_components, app),
             UICommand::ShowFilter => exec_show_filter(ui_components, app),
             UICommand::ResetFilter => exec_reset_filter(app),
-            UICommand::ToggleTagFilter => exec_toggle_tag_filter(app),
+            UICommand::CycleTagFilter => exec_toggle_tag_filter(app),
             UICommand::ShowFuzzyFind => exec_show_fuzzy_find(ui_components, app),
             UICommand::ToggleEditorVisualMode => exec_toggle_editor_visual_mode(ui_components),
             UICommand::ToggleFullScreenMode => exec_toggle_full_screen_mode(app),
@@ -342,7 +342,7 @@ impl UICommand {
             UICommand::MulSelExportEntries => not_implemented(),
             UICommand::ShowFilter => continue_show_filter(ui_components, app, msg_box_result).await,
             UICommand::ResetFilter => not_implemented(),
-            UICommand::ToggleTagFilter => not_implemented(),
+            UICommand::CycleTagFilter => not_implemented(),
             UICommand::ShowFuzzyFind => {
                 continue_fuzzy_find(ui_components, app, msg_box_result).await
             }

--- a/src/app/ui/commands/mod.rs
+++ b/src/app/ui/commands/mod.rs
@@ -53,6 +53,7 @@ pub enum UICommand {
     MulSelExportEntries,
     ShowFilter,
     ResetFilter,
+    ToggleTagFilter,
     ShowFuzzyFind,
     ToggleEditorVisualMode,
     ToggleFullScreenMode,
@@ -174,6 +175,10 @@ impl UICommand {
                 "Reset filter",
                 "Reset the applied filter on journals",
             ),
+            UICommand::ToggleTagFilter => CommandInfo::new(
+                "Toggle Tag Filter",
+                "Cycle through the tag filters",
+            ),
             UICommand::ShowFuzzyFind => CommandInfo::new(
                 "Fuzzy find",
                 "Open fuzzy find popup for journals",
@@ -258,6 +263,7 @@ impl UICommand {
             UICommand::MulSelExportEntries => exec_export_selected_entries(ui_components, app),
             UICommand::ShowFilter => exec_show_filter(ui_components, app),
             UICommand::ResetFilter => exec_reset_filter(app),
+            UICommand::ToggleTagFilter => exec_toggle_tag_filter(app),
             UICommand::ShowFuzzyFind => exec_show_fuzzy_find(ui_components, app),
             UICommand::ToggleEditorVisualMode => exec_toggle_editor_visual_mode(ui_components),
             UICommand::ToggleFullScreenMode => exec_toggle_full_screen_mode(app),
@@ -336,6 +342,7 @@ impl UICommand {
             UICommand::MulSelExportEntries => not_implemented(),
             UICommand::ShowFilter => continue_show_filter(ui_components, app, msg_box_result).await,
             UICommand::ResetFilter => not_implemented(),
+            UICommand::ToggleTagFilter => not_implemented(),
             UICommand::ShowFuzzyFind => {
                 continue_fuzzy_find(ui_components, app, msg_box_result).await
             }


### PR DESCRIPTION
see the comments in #455

Now you can press `Ctrl-t` to toggle the tag filter.

Let me know if you like this and I think we can add the key binding text to the bottom.
