### PR TITLE
Added: Provide Configuration for entries datum visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,12 @@ history_limit = 10  # Sets the maximum changes limit for the undo & redo stacks.
 
 colored_tags = true   # Sets if automatically coloring for tags is enabled.
 
+# Sets the visibility option for the datum of journals. Available options:
+#  - `show`: Render datum in journals list.
+#  - `hide`: Hide datum without providing an extra empty line for journal without `priority` value. 
+#  - `empty_line`: Hide datum providing an extra empty line for journal without `priority` value.
+datum_visibility = "show"  
+
 [export]
 default_path = "<Absolute_path_to_export_directory>"   # Optional default path to export multiple journals or a single journal's content. Falls back to the current directory if not specified.
 show_confirmation = true   # Show confirmation after successful export.

--- a/src/app/ui/entries_list/mod.rs
+++ b/src/app/ui/entries_list/mod.rs
@@ -15,8 +15,8 @@ use ratatui::{
 
 use backend::DataProvider;
 
-use crate::app::keymap::Keymap;
 use crate::app::App;
+use crate::{app::keymap::Keymap, settings::DatumVisibility};
 
 use super::INACTIVE_CONTROL_COLOR;
 use super::{UICommand, ACTIVE_CONTROL_COLOR};
@@ -85,35 +85,43 @@ impl<'a> EntriesList {
                     .collect();
 
                 // *** Date & Priority ***
-                let date_priority_lines = if let Some(prio) = entry.priority {
-                    let one_liner = format!(
-                        "{},{},{} | Priority: {}",
-                        entry.date.day(),
-                        entry.date.month(),
-                        entry.date.year(),
-                        prio
-                    );
+                let date_priority_lines = match (app.settings.datum_visibility, entry.priority) {
+                    (DatumVisibility::Show, Some(prio)) => {
+                        let one_liner = format!(
+                            "{},{},{} | Priority: {}",
+                            entry.date.day(),
+                            entry.date.month(),
+                            entry.date.year(),
+                            prio
+                        );
 
-                    if one_liner.len() > area.width as usize - LIST_INNER_MARGIN {
-                        vec![
-                            format!(
-                                "{},{},{}",
-                                entry.date.day(),
-                                entry.date.month(),
-                                entry.date.year()
-                            ),
-                            format!("Priority: {prio}"),
-                        ]
-                    } else {
-                        vec![one_liner]
+                        if one_liner.len() > area.width as usize - LIST_INNER_MARGIN {
+                            vec![
+                                format!(
+                                    "{},{},{}",
+                                    entry.date.day(),
+                                    entry.date.month(),
+                                    entry.date.year()
+                                ),
+                                format!("Priority: {prio}"),
+                            ]
+                        } else {
+                            vec![one_liner]
+                        }
                     }
-                } else {
-                    vec![format!(
-                        "{},{},{}",
-                        entry.date.day(),
-                        entry.date.month(),
-                        entry.date.year()
-                    )]
+                    (DatumVisibility::Show, None) => {
+                        vec![format!(
+                            "{},{},{}",
+                            entry.date.day(),
+                            entry.date.month(),
+                            entry.date.year()
+                        )]
+                    }
+                    (DatumVisibility::Hide, None) => Vec::new(),
+                    (DatumVisibility::EmptyLine, None) => vec![String::new()],
+                    (_, Some(prio)) => {
+                        vec![format!("Priority: {}", prio)]
+                    }
                 };
 
                 let date_lines = date_priority_lines.iter().map(|line| {

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -49,6 +49,9 @@ pub struct Settings {
     pub history_limit: usize,
     #[serde(default = "default_colored_tags")]
     pub colored_tags: bool,
+    #[serde(default)]
+    /// Sets the visibility options for the datum of journals when rendered in entries list.
+    pub datum_visibility: DatumVisibility,
 }
 
 impl Default for Settings {
@@ -66,8 +69,23 @@ impl Default for Settings {
             sync_os_clipboard: Default::default(),
             history_limit: default_history_limit(),
             colored_tags: default_colored_tags(),
+            datum_visibility: Default::default(),
         }
     }
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, ValueEnum, Clone, Copy, Default)]
+#[serde(rename_all = "snake_case")]
+/// Represents the visibility options for the datum of journals when rendered in entries list.
+pub enum DatumVisibility {
+    #[default]
+    /// Render the datum in entry list.
+    Show,
+    /// Hide the datum without providing an extra empty line if `priority` filed for the entry is
+    /// empty too.
+    Hide,
+    /// Hide the datum providing an extra empty line if `priority` filed for the entry is empty.
+    EmptyLine,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, ValueEnum, Clone, Copy, Default)]
@@ -139,6 +157,7 @@ impl Settings {
             sync_os_clipboard: _,
             history_limit: _,
             colored_tags: _,
+            datum_visibility: _,
         } = self;
 
         if self.backend_type.is_none() {


### PR DESCRIPTION
This PR closes #423 

It provides the configuration to control the visibility of the datum field in journals list with the options `show`, `hide` and `empty_line`.

The description has been added to the configuration section in README as well.

Here is the copy of the added configuration section:
```toml
# Sets the visibility option for the datum of journals. Available options:
#  - `show`: Render datum in journals list.
#  - `hide`: Hide datum without providing an extra empty line for journal without `priority` value. 
#  - `empty_line`: Hide datum providing an extra empty line for journal without `priority` value.
datum_visibility = "show"  
```