### PR TITLE
Added: Support Cycling Through Tags via Keybinding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
@@ -132,23 +132,23 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -204,9 +204,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cassowary"
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.18"
+version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
+checksum = "9540e661f81799159abee814118cc139a2004b3a3aa3ea37724a1b66530b90e0"
 dependencies = [
  "jobserver",
  "libc",
@@ -567,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "3.2.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
+checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
 
 [[package]]
 name = "etcetera"
@@ -760,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 
 [[package]]
 name = "git2"
@@ -843,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -944,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libgit2-sys"
@@ -1064,11 +1064,11 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
@@ -1472,9 +1472,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "powerfmt"
@@ -1502,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.36.1"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96a05e2e8efddfa51a84ca47cec303fac86c8541b686d37cac5efc0e094417bc"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
 dependencies = [
  "memchr",
 ]
@@ -1592,9 +1592,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "355ae415ccd3a04315d3f8246e86d67689ea74d88d915576e1589a351062a13b"
 dependencies = [
  "bitflags",
 ]
@@ -1638,9 +1638,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.36"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags",
  "errno",
@@ -1697,9 +1697,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1739,9 +1739,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -2152,9 +2152,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "81b9b4733a9c8b8aaa20634df36eeb68cc0c0669f2e18fb287006b496a14195d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2335,9 +2335,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
  "serde",
@@ -2446,9 +2446,9 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-linebreak"
@@ -2458,9 +2458,9 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
@@ -2473,9 +2473,9 @@ checksum = "52ea75f83c0137a9b98608359a5f1af8144876eb67bcb1ce837368e906a9f524"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-truncate"
@@ -2490,9 +2490,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode_categories"
@@ -2869,9 +2869,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ TUI-Journal is a terminal-based application written in Rust that allows you to w
 - Transfer text between the built-in editor and the system clipboard using Cut, Copy, and Paste.
 - Optionally sync the clipboard between the built-in editor and the operating system, with vim and emacs keybindings.
 - Sorting and full-screen preferences in the App State will be retained.
+- Easily cycle through tags in the main view with a single command \<Ctrl-t\>, applying the current filter for quick navigation.
 - See the keybindings from inside the app
 - Cross-platform compatibility (Windows, macOS, Linux, NetBSD).
 

--- a/src/app/filter/criterion.rs
+++ b/src/app/filter/criterion.rs
@@ -1,6 +1,6 @@
 use backend::Entry;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub enum FilterCriterion {
     Tag(String),
     Title(String),

--- a/src/app/filter/criterion.rs
+++ b/src/app/filter/criterion.rs
@@ -1,6 +1,6 @@
 use backend::Entry;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum FilterCriterion {
     Tag(String),
     Title(String),

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -149,7 +149,7 @@ pub(crate) fn get_global_keymaps() -> Vec<Keymap> {
         ),
         Keymap::new(
             Input::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
-            UICommand::ToggleTagFilter,
+            UICommand::CycleTagFilter,
         ),
         Keymap::new(
             Input::new(KeyCode::Char('u'), KeyModifiers::NONE),

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -148,6 +148,10 @@ pub(crate) fn get_global_keymaps() -> Vec<Keymap> {
             UICommand::ToggleFullScreenMode,
         ),
         Keymap::new(
+            Input::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
+            UICommand::ToggleTagFilter,
+        ),
+        Keymap::new(
             Input::new(KeyCode::Char('u'), KeyModifiers::NONE),
             UICommand::Undo,
         ),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -418,6 +418,31 @@ where
             .and_then(|c| c.get_tag_color(tag))
     }
 
+    pub fn cycle_tags_in_filter(&mut self) {
+        let tags = self.get_all_tags();
+        let tag_filter = self.filter.as_ref().and_then(|f| {
+            let filter = &f.criteria;
+            tags.iter()
+                .position(|tag| {
+                    filter
+                        .iter()
+                        .any(|v| v == &FilterCriterion::Tag(tag.to_string()))
+                })
+                .and_then(|index| tags.get(index + 1))
+                .map(|tag| FilterCriterion::Tag(tag.to_string()))
+        });
+
+        if let Some(filter) = tag_filter.or(tags
+            .first()
+            .map(|tag| FilterCriterion::Tag(tag.to_string())))
+        {
+            self.apply_filter(Some(Filter {
+                criteria: vec![filter],
+                ..Default::default()
+            }));
+        }
+    }
+
     /// Assigns priority to all entries that don't have a priority assigned to
     async fn assign_priority_to_entries(&self, priority: u32) -> anyhow::Result<()> {
         self.data_provide

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -457,7 +457,7 @@ where
                     let tag_pos = all_tags
                         .iter()
                         .position(|t| t == current_tag)
-                        .expect("Tag from filter must exist in current tags");
+                        .unwrap_or_default();
 
                     let next_index = (tag_pos + 1) % all_tags.len();
 

--- a/src/app/test/filter.rs
+++ b/src/app/test/filter.rs
@@ -1,0 +1,209 @@
+use super::*;
+use crate::app::filter::CriteriaRelation;
+
+#[tokio::test]
+async fn test_filter() {
+    let mut app = create_default_app();
+    app.load_entries().await.unwrap();
+
+    app.current_entry_id = Some(0);
+
+    let mut filter = Filter::default();
+    filter
+        .criteria
+        .push(FilterCriterion::Title(String::from("Title 2")));
+    app.apply_filter(Some(filter));
+
+    assert_eq!(app.get_active_entries().count(), 1);
+    assert!(app.get_current_entry().is_none());
+    let entry = app.get_active_entries().next().unwrap();
+    assert_eq!(entry.id, 1);
+    assert_eq!(entry.title, String::from("Title 2"));
+    assert!(app.get_entry(0).is_none());
+
+    app.apply_filter(None);
+    assert_eq!(app.get_active_entries().count(), 2);
+}
+
+#[tokio::test]
+async fn test_filter_priority() {
+    let mut app = create_default_app();
+    app.load_entries().await.unwrap();
+
+    app.current_entry_id = Some(0);
+
+    let mut filter = Filter::default();
+    filter.criteria.push(FilterCriterion::Priority(1));
+    app.apply_filter(Some(filter));
+
+    assert_eq!(app.get_active_entries().count(), 1);
+    assert!(app.get_current_entry().is_none());
+    let entry = app.get_active_entries().next().unwrap();
+    assert_eq!(entry.id, 1);
+    assert_eq!(entry.priority, Some(1));
+    assert!(app.get_entry(0).is_none());
+
+    app.apply_filter(None);
+    assert_eq!(app.get_active_entries().count(), 2);
+}
+
+#[tokio::test]
+async fn test_filter_relations() {
+    let mut app = create_default_app();
+    app.load_entries().await.unwrap();
+    let criteria = vec![
+        FilterCriterion::Content("1".into()),
+        FilterCriterion::Content("2".into()),
+    ];
+
+    let mut filter = Filter {
+        criteria,
+        relation: CriteriaRelation::Or,
+    };
+
+    app.apply_filter(Some(filter.clone()));
+
+    assert_eq!(app.get_active_entries().count(), 2);
+
+    filter.relation = CriteriaRelation::And;
+    app.apply_filter(Some(filter));
+
+    assert_eq!(app.get_active_entries().count(), 0);
+}
+
+#[tokio::test]
+async fn cycle_tag_no_tags() {
+    let mut app = App::new(MockDataProvider::default(), Settings::default());
+    app.load_entries().await.unwrap();
+
+    // Check empty app doesn't panic
+    app.cycle_tags_in_filter();
+
+    app.add_entry("Title_1".into(), Utc::now(), Vec::new(), Some(1))
+        .await
+        .unwrap();
+    app.add_entry("Title_2".into(), Utc::now(), Vec::new(), Some(2))
+        .await
+        .unwrap();
+
+    // No panic on cycle with not tags
+    app.cycle_tags_in_filter();
+}
+
+#[tokio::test]
+async fn cycle_tag_no_existing_filter() {
+    // default project has two tags
+    let mut app = create_default_app();
+    app.load_entries().await.unwrap();
+
+    for _ in 0..3 {
+        app.cycle_tags_in_filter();
+
+        // Filter exits and have one criteria
+        assert_eq!(app.filter.as_ref().unwrap().criteria.len(), 1);
+
+        // Check the criteria
+        let criteria = app
+            .filter
+            .as_ref()
+            .and_then(|f| f.criteria.first())
+            .unwrap();
+        assert!(
+            matches!(criteria, FilterCriterion::Tag(_)),
+            "Expected Tag criteria. found {criteria:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn cycle_tag_exact() {
+    // default project has two tags "Tag 1" "Tag 2"
+    let mut app = create_default_app();
+    app.load_entries().await.unwrap();
+
+    app.cycle_tags_in_filter();
+
+    // First iteration must be first tag
+    match app
+        .filter
+        .as_ref()
+        .and_then(|f| f.criteria.first())
+        .unwrap()
+    {
+        FilterCriterion::Tag(s) => assert_eq!(s, "Tag 1"),
+        invalid => panic!("Invalid criteria: {invalid:?}"),
+    }
+
+    app.cycle_tags_in_filter();
+
+    // Second iteration must be second tag
+    match app
+        .filter
+        .as_ref()
+        .and_then(|f| f.criteria.first())
+        .unwrap()
+    {
+        FilterCriterion::Tag(s) => assert_eq!(s, "Tag 2"),
+        invalid => panic!("Invalid criteria: {invalid:?}"),
+    }
+
+    app.cycle_tags_in_filter();
+
+    // Third iteration must go back to first tag
+    match app
+        .filter
+        .as_ref()
+        .and_then(|f| f.criteria.first())
+        .unwrap()
+    {
+        FilterCriterion::Tag(s) => assert_eq!(s, "Tag 1"),
+        invalid => panic!("Invalid criteria: {invalid:?}"),
+    }
+}
+
+#[tokio::test]
+async fn cycle_tag_existing_filter() {
+    // default project has two tags "Tag 1" "Tag 2"
+    let mut app = create_default_app();
+    app.load_entries().await.unwrap();
+    app.add_entry(
+        "Title_3".into(),
+        Utc::now(),
+        vec!["New".into(), "Other".into()],
+        Some(55),
+    )
+    .await
+    .unwrap();
+
+    let mut filter = Filter::default();
+    filter.criteria.push(FilterCriterion::Title("Title".into()));
+    app.apply_filter(Some(filter));
+
+    app.cycle_tags_in_filter();
+
+    // Filter exits and have two criteria
+    assert_eq!(app.filter.as_ref().unwrap().criteria.len(), 2);
+
+    // Criteria must be one tag
+    assert_eq!(
+        app.filter
+            .as_ref()
+            .unwrap()
+            .criteria
+            .iter()
+            .filter(|c| matches!(c, FilterCriterion::Tag(_)))
+            .count(),
+        1
+    );
+    // Criteria must be one title
+    assert_eq!(
+        app.filter
+            .as_ref()
+            .unwrap()
+            .criteria
+            .iter()
+            .filter(|c| matches!(c, FilterCriterion::Title(_)))
+            .count(),
+        1
+    );
+}

--- a/src/app/test/mod.rs
+++ b/src/app/test/mod.rs
@@ -1,6 +1,6 @@
 use chrono::TimeZone;
 
-use crate::app::filter::CriteriaRelation;
+mod filter;
 
 use self::mock::MockDataProvider;
 
@@ -129,76 +129,6 @@ async fn test_current_entry() {
     assert_eq!(current_entry.id, 0);
     assert_eq!(current_entry.tags.len(), 2);
     assert_eq!(current_entry.title, String::from("Title 1"));
-}
-
-#[tokio::test]
-async fn test_filter() {
-    let mut app = create_default_app();
-    app.load_entries().await.unwrap();
-
-    app.current_entry_id = Some(0);
-
-    let mut filter = Filter::default();
-    filter
-        .criteria
-        .push(FilterCriterion::Title(String::from("Title 2")));
-    app.apply_filter(Some(filter));
-
-    assert_eq!(app.get_active_entries().count(), 1);
-    assert!(app.get_current_entry().is_none());
-    let entry = app.get_active_entries().next().unwrap();
-    assert_eq!(entry.id, 1);
-    assert_eq!(entry.title, String::from("Title 2"));
-    assert!(app.get_entry(0).is_none());
-
-    app.apply_filter(None);
-    assert_eq!(app.get_active_entries().count(), 2);
-}
-
-#[tokio::test]
-async fn test_filter_priority() {
-    let mut app = create_default_app();
-    app.load_entries().await.unwrap();
-
-    app.current_entry_id = Some(0);
-
-    let mut filter = Filter::default();
-    filter.criteria.push(FilterCriterion::Priority(1));
-    app.apply_filter(Some(filter));
-
-    assert_eq!(app.get_active_entries().count(), 1);
-    assert!(app.get_current_entry().is_none());
-    let entry = app.get_active_entries().next().unwrap();
-    assert_eq!(entry.id, 1);
-    assert_eq!(entry.priority, Some(1));
-    assert!(app.get_entry(0).is_none());
-
-    app.apply_filter(None);
-    assert_eq!(app.get_active_entries().count(), 2);
-}
-
-#[tokio::test]
-async fn test_filter_relations() {
-    let mut app = create_default_app();
-    app.load_entries().await.unwrap();
-    let criteria = vec![
-        FilterCriterion::Content("1".into()),
-        FilterCriterion::Content("2".into()),
-    ];
-
-    let mut filter = Filter {
-        criteria,
-        relation: CriteriaRelation::Or,
-    };
-
-    app.apply_filter(Some(filter.clone()));
-
-    assert_eq!(app.get_active_entries().count(), 2);
-
-    filter.relation = CriteriaRelation::And;
-    app.apply_filter(Some(filter));
-
-    assert_eq!(app.get_active_entries().count(), 0);
 }
 
 async fn add_extra_entries_drafts(app: &mut App<MockDataProvider>) {

--- a/src/app/ui/commands/entries_list_cmd.rs
+++ b/src/app/ui/commands/entries_list_cmd.rs
@@ -391,8 +391,35 @@ pub fn exec_reset_filter<D: DataProvider>(app: &mut App<D>) -> CmdResult {
     Ok(HandleInputReturnType::Handled)
 }
 
-pub fn exec_toggle_tag_filter<D: DataProvider>(app: &mut App<D>) -> CmdResult {
-    app.cycle_tags_in_filter();
+pub fn exec_cycle_tag_filter<D: DataProvider>(
+    ui_components: &mut UIComponents,
+    app: &mut App<D>,
+) -> CmdResult {
+    if ui_components.has_unsaved() {
+        ui_components.show_unsaved_msg_box(Some(UICommand::CycleTagFilter));
+    } else {
+        app.cycle_tags_in_filter();
+    }
+
+    Ok(HandleInputReturnType::Handled)
+}
+
+pub async fn continue_cycle_tag_filter<'a, D: DataProvider>(
+    ui_components: &mut UIComponents<'a>,
+    app: &mut App<D>,
+    msg_box_result: MsgBoxResult,
+) -> CmdResult {
+    match msg_box_result {
+        MsgBoxResult::Ok | MsgBoxResult::Cancel => {}
+        MsgBoxResult::Yes => {
+            exec_save_entry_content(ui_components, app).await?;
+            app.cycle_tags_in_filter();
+        }
+        MsgBoxResult::No => {
+            discard_current_content(ui_components, app);
+            app.cycle_tags_in_filter();
+        }
+    }
 
     Ok(HandleInputReturnType::Handled)
 }

--- a/src/app/ui/commands/entries_list_cmd.rs
+++ b/src/app/ui/commands/entries_list_cmd.rs
@@ -1,11 +1,6 @@
 use std::{collections::HashMap, env};
 
-use crate::app::{
-    external_editor,
-    filter::{Filter, FilterCriterion},
-    ui::*,
-    App, UIComponents,
-};
+use crate::app::{external_editor, ui::*, App, UIComponents};
 
 use backend::DataProvider;
 
@@ -397,27 +392,7 @@ pub fn exec_reset_filter<D: DataProvider>(app: &mut App<D>) -> CmdResult {
 }
 
 pub fn exec_toggle_tag_filter<D: DataProvider>(app: &mut App<D>) -> CmdResult {
-    let tags = app.get_all_tags();
-    let first_tag_filter = tags
-        .first()
-        .map(|tag| FilterCriterion::Tag(tag.to_string()));
-
-    let tag_filter = app.filter.as_ref().and_then(|f| {
-        let filter = &f.criteria;
-        tags.iter()
-            .position(|tag| {
-                filter
-                    .iter()
-                    .any(|v| v == &FilterCriterion::Tag(tag.to_string()))
-            })
-            .and_then(|index| tags.get(index + 1))
-            .map(|tag| FilterCriterion::Tag(tag.to_string()))
-    });
-
-    app.apply_filter(Some(Filter {
-        criteria: vec![tag_filter.or(first_tag_filter).unwrap()],
-        ..Default::default()
-    }));
+    app.cycle_tags_in_filter();
 
     Ok(HandleInputReturnType::Handled)
 }

--- a/src/app/ui/commands/mod.rs
+++ b/src/app/ui/commands/mod.rs
@@ -176,7 +176,7 @@ impl UICommand {
                 "Reset the applied filter on journals",
             ),
             UICommand::CycleTagFilter => CommandInfo::new(
-                "Toggle Tag Filter",
+                "Cycle Tag Filter",
                 "Cycle through the tag filters",
             ),
             UICommand::ShowFuzzyFind => CommandInfo::new(

--- a/src/app/ui/commands/mod.rs
+++ b/src/app/ui/commands/mod.rs
@@ -263,7 +263,7 @@ impl UICommand {
             UICommand::MulSelExportEntries => exec_export_selected_entries(ui_components, app),
             UICommand::ShowFilter => exec_show_filter(ui_components, app),
             UICommand::ResetFilter => exec_reset_filter(app),
-            UICommand::CycleTagFilter => exec_toggle_tag_filter(app),
+            UICommand::CycleTagFilter => exec_cycle_tag_filter(ui_components, app),
             UICommand::ShowFuzzyFind => exec_show_fuzzy_find(ui_components, app),
             UICommand::ToggleEditorVisualMode => exec_toggle_editor_visual_mode(ui_components),
             UICommand::ToggleFullScreenMode => exec_toggle_full_screen_mode(app),
@@ -342,7 +342,9 @@ impl UICommand {
             UICommand::MulSelExportEntries => not_implemented(),
             UICommand::ShowFilter => continue_show_filter(ui_components, app, msg_box_result).await,
             UICommand::ResetFilter => not_implemented(),
-            UICommand::CycleTagFilter => not_implemented(),
+            UICommand::CycleTagFilter => {
+                continue_cycle_tag_filter(ui_components, app, msg_box_result).await
+            }
             UICommand::ShowFuzzyFind => {
                 continue_fuzzy_find(ui_components, app, msg_box_result).await
             }

--- a/src/app/ui/commands/mod.rs
+++ b/src/app/ui/commands/mod.rs
@@ -53,7 +53,7 @@ pub enum UICommand {
     MulSelExportEntries,
     ShowFilter,
     ResetFilter,
-    ToggleTagFilter,
+    CycleTagFilter,
     ShowFuzzyFind,
     ToggleEditorVisualMode,
     ToggleFullScreenMode,
@@ -175,7 +175,7 @@ impl UICommand {
                 "Reset filter",
                 "Reset the applied filter on journals",
             ),
-            UICommand::ToggleTagFilter => CommandInfo::new(
+            UICommand::CycleTagFilter => CommandInfo::new(
                 "Toggle Tag Filter",
                 "Cycle through the tag filters",
             ),
@@ -263,7 +263,7 @@ impl UICommand {
             UICommand::MulSelExportEntries => exec_export_selected_entries(ui_components, app),
             UICommand::ShowFilter => exec_show_filter(ui_components, app),
             UICommand::ResetFilter => exec_reset_filter(app),
-            UICommand::ToggleTagFilter => exec_toggle_tag_filter(app),
+            UICommand::CycleTagFilter => exec_toggle_tag_filter(app),
             UICommand::ShowFuzzyFind => exec_show_fuzzy_find(ui_components, app),
             UICommand::ToggleEditorVisualMode => exec_toggle_editor_visual_mode(ui_components),
             UICommand::ToggleFullScreenMode => exec_toggle_full_screen_mode(app),
@@ -342,7 +342,7 @@ impl UICommand {
             UICommand::MulSelExportEntries => not_implemented(),
             UICommand::ShowFilter => continue_show_filter(ui_components, app, msg_box_result).await,
             UICommand::ResetFilter => not_implemented(),
-            UICommand::ToggleTagFilter => not_implemented(),
+            UICommand::CycleTagFilter => not_implemented(),
             UICommand::ShowFuzzyFind => {
                 continue_fuzzy_find(ui_components, app, msg_box_result).await
             }

--- a/src/app/ui/commands/mod.rs
+++ b/src/app/ui/commands/mod.rs
@@ -53,6 +53,7 @@ pub enum UICommand {
     MulSelExportEntries,
     ShowFilter,
     ResetFilter,
+    ToggleTagFilter,
     ShowFuzzyFind,
     ToggleEditorVisualMode,
     ToggleFullScreenMode,
@@ -174,6 +175,10 @@ impl UICommand {
                 "Reset filter",
                 "Reset the applied filter on journals",
             ),
+            UICommand::ToggleTagFilter => CommandInfo::new(
+                "Toggle Tag Filter",
+                "Cycle through the tag filters",
+            ),
             UICommand::ShowFuzzyFind => CommandInfo::new(
                 "Fuzzy find",
                 "Open fuzzy find popup for journals",
@@ -258,6 +263,7 @@ impl UICommand {
             UICommand::MulSelExportEntries => exec_export_selected_entries(ui_components, app),
             UICommand::ShowFilter => exec_show_filter(ui_components, app),
             UICommand::ResetFilter => exec_reset_filter(app),
+            UICommand::ToggleTagFilter => exec_toggle_tag_filter(app),
             UICommand::ShowFuzzyFind => exec_show_fuzzy_find(ui_components, app),
             UICommand::ToggleEditorVisualMode => exec_toggle_editor_visual_mode(ui_components),
             UICommand::ToggleFullScreenMode => exec_toggle_full_screen_mode(app),
@@ -336,6 +342,7 @@ impl UICommand {
             UICommand::MulSelExportEntries => not_implemented(),
             UICommand::ShowFilter => continue_show_filter(ui_components, app, msg_box_result).await,
             UICommand::ResetFilter => not_implemented(),
+            UICommand::ToggleTagFilter => not_implemented(),
             UICommand::ShowFuzzyFind => {
                 continue_fuzzy_find(ui_components, app, msg_box_result).await
             }


### PR DESCRIPTION
This PR close #407.
This PR continues the great work of #458 

The whole feature will allow users to cycle through tags from the main view with the keybinding <Ctrl-t>
This was implemented in the PR #458 at first then  I continue working to it to cover some edge cases when there is already a filter applied and added unit tests.

The cycle will now respect the current filter and only change that tags their with the following logic:
* If there is no tags then the first one will be added
* If there is one tag only then the next tag will be applied
* If there is multiple tags then they'll be remove and the first one will be applied

Also the case if the current entry has unsaved changes is considered

Dependencies have been updated here as well