### PR TITLE
base dir instead

### DIFF
--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -198,11 +198,10 @@ fn get_settings_path() -> anyhow::Result<PathBuf> {
 }
 
 fn get_default_data_dir() -> anyhow::Result<PathBuf> {
-    UserDirs::new()
+    BaseDirs::new()
         .map(|user_dirs| {
             user_dirs
-                .document_dir()
-                .unwrap_or(user_dirs.home_dir())
+                .data_dir()
                 .join("tui-journal")
         })
         .context("Default entries directory path couldn't be retrieved")


### PR DESCRIPTION
Create a direction in user home that only had one file is kinda messy let's just use local share instead
that includes both sqlite database and json states.