### PR TITLE
Change: Release on Both Arm and X86 for MacOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
             container: rust
             dependencies: "libssl-dev"
           - os: macos-latest
+            arch: x86_64
+          - os: macos-latest
+            arch: arm64
           - os: windows-latest
 
     steps:
@@ -39,9 +42,12 @@ jobs:
       if: matrix.dependencies
       run: apt update && apt install -y ${{ matrix.dependencies }}
 
-    - name: Build Release Mac
-      if: matrix.os == 'macos-latest'
-      run: make release-mac
+    - name: Build Release Mac x86_64
+      if: matrix.os == 'macos-latest' && matrix.arch == 'x86_64'
+      run: make release-mac-x86_64
+    - name: Build Release Mac ARM64
+      if: matrix.os == 'macos-latest' && matrix.arch == 'arm64'
+      run: make release-mac-arm64
     - name: Build Release Linux
       if: matrix.os == 'ubuntu-latest'
       run: make release-linux

--- a/Makefile
+++ b/Makefile
@@ -14,15 +14,21 @@ clippy:
 build-release:
 	cargo build --release
 
-build-release_mac_arm:
-	cargo build --release --target=aarch64-apple-darwin
-
-release-mac: build-release
-	strip target/release/tjournal
-	otool -L target/release/tjournal
+release-mac-x86_64: build-release
+	cargo build --release --target=x86_64-apple-darwin
+	strip target/x86_64-apple-darwin/release/tjournal
+	otool -L target/x86_64-apple-darwin/release/tjournal
 	mkdir -p release
-	tar -C ./target/release/ -czvf ./release/tjournal-mac.tar.gz ./tjournal
-	ls -lisah ./release/tjournal-mac.tar.gz
+	tar -C ./target/x86_64-apple-darwin/release/ -czvf ./release/tjournal-mac-x86_64.tar.gz ./tjournal
+	ls -lisah ./release/tjournal-mac-x86_64.tar.gz
+
+release-mac-arm64: build-release
+	cargo build --release --target=aarch64-apple-darwin
+	strip target/aarch64-apple-darwin/release/tjournal
+	otool -L target/aarch64-apple-darwin/release/tjournal
+	mkdir -p release
+	tar -C ./target/aarch64-apple-darwin/release/ -czvf ./release/tjournal-mac-arm64.tar.gz ./tjournal
+	ls -lisah ./release/tjournal-mac-arm64.tar.gz
 
 release-win: build-release
 	mkdir -p release


### PR DESCRIPTION
This PR add release on X86 architecture on MacOS besides the default Arm one.

* Update the make file to have two jobs for each architecture.
* Update release GitHub action to include these architectures too.