### PR TITLE
Fixed: Fix Homebrew GitHub Action

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,23 +1,30 @@
 name: Homebrew Bump Formula
 on:
   workflow_dispatch:
-  # Not all binaries will be available at the moment when release is published.
-  # release:
-  #   types: [published]
+  release:
+    types: [released]
 jobs:
   homebrew:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2 
     - name: Get Latest Tag
       id: ltag
-      run: echo "GIT_TAG=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
+      run: |
+        git fetch --tags
+        echo "GIT_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_OUTPUT
+    - name: Debug tag
+      run: |
+        echo "-------------------------------------------------------------"
+        echo ${{ steps.ltag.outputs.GIT_TAG }}
+        echo "-------------------------------------------------------------"
 
     - name: Bump Homebrew Formula
-      uses: mislav/bump-homebrew-formula-action@v3
-      env:
-        COMMITTER_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+      uses: dawidd6/action-homebrew-bump-formula@v4
       with:
-        homebrew-tap: AmmarAbouZor/homebrew-tui-journal
-        formula-name: tui-journal
-        formula-path: Formula/tui-journal.rb
-        tag-name: ${{ steps.ltag.outputs.GIT_TAG }}
+        token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+        tap: AmmarAbouZor/homebrew-tui-journal
+        formula: tui-journal
+        tag: ${{ steps.ltag.outputs.GIT_TAG }}
+        force: true

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2 
+      uses: actions/checkout@v4
     - name: Get Latest Tag
       id: ltag
       run: |
         git fetch --tags
-        echo "GIT_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_OUTPUT
+        echo "GIT_TAG=$(git describe --tags "$(git rev-list --tags --max-count=1)")" >> "$GITHUB_OUTPUT"
     - name: Debug tag
       run: |
         echo "-------------------------------------------------------------"

--- a/README.md
+++ b/README.md
@@ -121,6 +121,27 @@ On NetBSD a pre-compiled binary built with default features is available from th
 pkgin install tui-journal
 ```
 
+### Nix
+
+TUI-Journal is available on the [Nix package manager](https://nixos.org/). You can install it using the following commands:
+
+```bash
+# On NixOS:
+nix-env -iA nixos.tui-journal
+
+# On Non NixOS:
+nix-env -iA nixpkgs.tui-journal
+```
+For more information, visit the [TUI-Journal package page on Nix](https://search.nixos.org/packages?show=tui-journal).
+
+### Homebrew (macOS and Linux)
+
+For macOS and Linux users, TUI-Journal can be installed via Homebrew using a direct installation method:
+
+```bash
+brew install AmmarAbouZor/homebrew-tui-journal/tui-journal
+```
+
 ### Build & Install via Cargo 
 
 Ensure you have [Rust](https://www.rust-lang.org/tools/install) installed on your system.


### PR DESCRIPTION
This PR closes #457 

It fixes the old pipeline to ensure the homebrew tab is updated on each release or manually if needed.
This PR updates the README adding nix and homebrew installation instructions.

This install command is
```bash
brew tap AmmarAbouZor/homebrew-tui-journal/tui-journal
```