### PR TITLE
CI: Include minimal supported rust version & Increase Min Version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,16 +24,22 @@ jobs:
           args: -color
 
   build:
-
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Run on latest and minimal supported rust versions.
+        rust-version: ["stable", "1.75.0"]
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install Latest Rust
+    - name: Install Rust
       run: |
-        rustup update --no-self-update ${{ env.RUST_CHANNEL }}
-        rustup default ${{ env.RUST_CHANNEL }}
+        echo "Installing Rust ${{ matrix.rust-version }}"
+        rustup update --no-self-update ${{ matrix.rust-version  }}
+        rustup default ${{ matrix.rust-version  }}
 
     - name: Rust Cache
       uses: Swatinem/rust-cache@v2.7.5
@@ -45,7 +51,7 @@ jobs:
       run: cargo check --no-default-features -F sqlite --verbose
 
     - name: Clippy
-      run: cargo clippy
+      run: cargo clippy --verbose
 
     - name: Build
       run: cargo build --verbose

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,12 +51,14 @@ jobs:
       run: cargo check --no-default-features -F sqlite --verbose
 
     - name: Clippy
+      if: ${{ matrix.rust-version == 'stable' }}
       run: cargo clippy --verbose
 
     - name: Build
       run: cargo build --verbose
 
     - name: Run tests
+      if: ${{ matrix.rust-version == 'stable' }}
       run: cargo test --verbose
 
   cffconvert:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         # Run on latest and minimal supported rust versions.
-        rust-version: ["stable", "1.75.0"]
+        rust-version: ["stable", "1.81.0"]
 
     steps:
     - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/ammarabouzor/tui-journal"
 readme = "README.md"
 categories = ["command-line-utilities"]
 keywords = ["tui", "terminal-app", "journal", "cli", "ui"]
-rust-version = "1.75.0"
+rust-version = "1.81.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
This PR closes #497 

It includes:
* Run the CI checks on both latest and the minimal supported rust version
* Increase Rust minimal Version to 1.81.0
* Fix undefined rust version in previous runs.
* Add verbose flag for `rust clippy`