### PR TITLE
Added: Smart Case for Filter & Fuzzy Finder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2611,6 +2620,7 @@ dependencies = [
 name = "tui-journal"
 version = "0.12.1"
 dependencies = [
+ "aho-corasick",
  "anyhow",
  "arboard",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = "2.0.2"
 toml = "0.8.16"
 sqlx = {version = "0.8.1", features = ["runtime-tokio-native-tls", "sqlite", "chrono"], optional = true}
 futures-util = { version = "0.3", default-features = false }
+aho-corasick = "1.1"
 
 scopeguard = "1.2.0"
 git2 = { version = "0.19.0", default-features = false }

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ TUI-Journal is a terminal-based application written in Rust that allows you to w
 - Create, edit, and delete entries easily.
 - Edit journal content with the built-in editor or use your favourite terminal text editor from within the app.
 - Add custom colored tags to the journals and use them in the built-in filter.
-- Fuzzy Finder: Locate your desired journal with lightning-fast speed.
-- Search functions for journals title and content in the built-in filter.
+- Fuzzy Finder: Locate your desired journal with lightning-fast speed using smart-case search.
+- Smart search functions for journals title and content in the built-in filter.
 - Sort the journals based on their date, priority and title.
 - Control many journals at once via the multi-select mode
 - History management with Undo and Redo actions to easily revert or reapply changes in your entries

--- a/src/app/filter/criterion.rs
+++ b/src/app/filter/criterion.rs
@@ -1,3 +1,4 @@
+use aho_corasick::AhoCorasick;
 use backend::Entry;
 
 #[derive(Debug, Clone)]
@@ -13,8 +14,36 @@ impl FilterCriterion {
     pub fn check_entry(&self, entry: &Entry) -> bool {
         match self {
             FilterCriterion::Tag(tag) => entry.tags.contains(tag),
-            FilterCriterion::Title(search) => entry.title.contains(search),
-            FilterCriterion::Content(search) => entry.content.contains(search),
+            FilterCriterion::Title(search) => {
+                // Use simple smart-case search for title
+                if search.chars().any(|c| c.is_uppercase()) {
+                    entry.title.contains(search)
+                } else {
+                    entry.title.to_lowercase().contains(search)
+                }
+            }
+            FilterCriterion::Content(search) => {
+                if search.chars().any(|c| c.is_uppercase()) {
+                    // Use simple search when pattern already has uppercase
+                    entry.content.contains(search)
+                } else {
+                    // Otherwise use case insensitive pattern matcher
+                    let ac = match AhoCorasick::builder()
+                        .ascii_case_insensitive(true)
+                        .build([&search])
+                    {
+                        Ok(ac) => ac,
+                        Err(err) => {
+                            log::error!(
+                                "Build AhoCorasick with pattern {search} failed with error: {err}"
+                            );
+                            return false;
+                        }
+                    };
+
+                    ac.find(&entry.content).is_some()
+                }
+            }
             FilterCriterion::Priority(prio) => entry.priority.is_some_and(|pr| pr == *prio),
         }
     }

--- a/src/app/test/filter.rs
+++ b/src/app/test/filter.rs
@@ -26,6 +26,52 @@ async fn test_filter() {
 }
 
 #[tokio::test]
+async fn test_title_smart_case() {
+    let mut app = create_default_app();
+    app.load_entries().await.unwrap();
+
+    app.current_entry_id = Some(0);
+    let mut filter = Filter::default();
+    filter
+        .criteria
+        .push(FilterCriterion::Title(String::from("title 2")));
+    app.apply_filter(Some(filter));
+
+    assert_eq!(app.get_active_entries().count(), 1);
+    assert!(app.get_current_entry().is_none());
+    let entry = app.get_active_entries().next().unwrap();
+    assert_eq!(entry.id, 1);
+    assert_eq!(entry.title, String::from("Title 2"));
+    assert!(app.get_entry(0).is_none());
+
+    app.apply_filter(None);
+    assert_eq!(app.get_active_entries().count(), 2);
+}
+
+#[tokio::test]
+async fn test_content_smart_case() {
+    let mut app = create_default_app();
+    app.load_entries().await.unwrap();
+
+    app.current_entry_id = Some(0);
+    let mut filter = Filter::default();
+    filter
+        .criteria
+        .push(FilterCriterion::Content(String::from("content 2")));
+    app.apply_filter(Some(filter));
+
+    assert_eq!(app.get_active_entries().count(), 1);
+    assert!(app.get_current_entry().is_none());
+    let entry = app.get_active_entries().next().unwrap();
+    assert_eq!(entry.id, 1);
+    assert_eq!(entry.content, String::from("Content 2"));
+    assert!(app.get_entry(0).is_none());
+
+    app.apply_filter(None);
+    assert_eq!(app.get_active_entries().count(), 2);
+}
+
+#[tokio::test]
 async fn test_filter_priority() {
     let mut app = create_default_app();
     app.load_entries().await.unwrap();

--- a/src/app/ui/fuzz_find/mod.rs
+++ b/src/app/ui/fuzz_find/mod.rs
@@ -57,7 +57,7 @@ impl<'a> FuzzFindPopup<'a> {
             search_query: None,
             filtered_entries: Vec::new(),
             list_state: ListState::default(),
-            matcher: SkimMatcherV2::default(),
+            matcher: SkimMatcherV2::default().smart_case(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,9 +38,8 @@ async fn main() -> Result<()> {
 
     app::run(&mut terminal, settings, pending_cmd)
         .await
-        .map_err(|err| {
+        .inspect_err(|err| {
             log::error!("[PANIC] {}", err.to_string());
-            err
         })?;
 
     // restore terminal


### PR DESCRIPTION
This PR closes #490 

It provides smart-case for Fuzzy finder and filter by default

* For fuzzy finder I just enabled the option on `SkimMatcherV2`
* For filter I add basic implementation for title since they are to long, but for content I've used [the crate aho_corasick](https://docs.rs/aho-corasick/latest/aho_corasick/)
* Unit tests for filter are added as well.