### PR TITLE
Added: Config path via CLI & State Path configurable & Fix default state path

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ Options:
   -s, --sqlite-file-path <FILE PATH>  Sets the entries sqlite file path and starts using it
   -b, --backend-type <BACKEND_TYPE>   Sets the backend type and starts using it [possible values: json, sqlite]
   -w, --write-config                  write the current settings to config file (this will rewrite the whole config file)
+  -c, --config <FLIE PAHT>            Specifies the path for the configuration file
+                                      (default path: <config-dir>/tui-journal/config.toml)
   -v, --verbose...                    Increases logging verbosity each use for up to 3 times
   -l, --log <FILE PATH>               Specifies a file to use for logging
                                       (default file: <cache_dir>/tui-journal/tui-journal.log)

--- a/README.md
+++ b/README.md
@@ -258,6 +258,10 @@ colored_tags = true   # Sets if automatically coloring for tags is enabled.
 #  - `empty_line`: Hide datum providing an extra empty line for journal without `priority` value.
 datum_visibility = "show"  
 
+# Sets the directory where the application persists its state between sessions.
+# Default are "~/<HOME>/.local/state/tui-journal/" on Linux and "C:\Users\Alice\AppData\Roaming\tui-journal\" on Windows 
+app_state_dir = "<STATE_DIRECTORY>/tui-journal/"
+
 [export]
 default_path = "<Absolute_path_to_export_directory>"   # Optional default path to export multiple journals or a single journal's content. Falls back to the current directory if not specified.
 show_confirmation = true   # Show confirmation after successful export.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -23,7 +23,7 @@ mod history;
 mod keymap;
 mod runner;
 mod sorter;
-mod state;
+pub mod state;
 #[cfg(test)]
 mod test;
 mod ui;
@@ -513,7 +513,7 @@ where
     }
 
     pub fn load_state(&mut self, ui_components: &mut UIComponents) {
-        let state = match AppState::load() {
+        let state = match AppState::load(&self.settings) {
             Ok(state) => state,
             Err(err) => {
                 ui_components.show_err_msg(format!(
@@ -527,7 +527,7 @@ where
     }
 
     pub fn persist_state(&self) -> anyhow::Result<()> {
-        self.state.save()?;
+        self.state.save(&self.settings)?;
 
         Ok(())
     }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 
 use super::*;
 
+const STATE_FILE_NAME: &str = "state.json";
+
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct AppState {
     pub sorter: Sorter,
@@ -12,8 +14,8 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn load() -> anyhow::Result<Self> {
-        let state_path = Self::get_path()?;
+    pub fn load(settings: &Settings) -> anyhow::Result<Self> {
+        let state_path = Self::get_persist_path(settings)?;
 
         let state = if state_path.exists() {
             let state_file = File::open(state_path)
@@ -27,8 +29,16 @@ impl AppState {
         Ok(state)
     }
 
-    pub fn save(&self) -> anyhow::Result<()> {
-        let state_path = Self::get_path()?;
+    fn get_persist_path(settings: &Settings) -> anyhow::Result<PathBuf> {
+        if let Some(path) = settings.app_state_dir.as_ref() {
+            Ok(path.join(STATE_FILE_NAME))
+        } else {
+            Self::default_persist_dir().map(|dir| dir.join(STATE_FILE_NAME))
+        }
+    }
+
+    pub fn save(&self, settings: &Settings) -> anyhow::Result<()> {
+        let state_path = Self::get_persist_path(settings)?;
         if let Some(parent) = state_path.parent() {
             fs::create_dir_all(parent)?;
         }
@@ -41,9 +51,16 @@ impl AppState {
         Ok(())
     }
 
-    fn get_path() -> anyhow::Result<PathBuf> {
+    /// Return the default path of the directory used to persist the application state.
+    /// It uses the state directories on supported platforms falling back to the data directory.
+    pub fn default_persist_dir() -> anyhow::Result<PathBuf> {
         BaseDirs::new()
-            .map(|base_dirs| base_dirs.data_dir().join("tui-journal").join("state.json"))
+            .map(|base_dirs| {
+                base_dirs
+                    .state_dir()
+                    .unwrap_or_else(|| base_dirs.data_dir())
+                    .join("tui-journal")
+            })
             .context("Config file path couldn't be retrieved")
     }
 }

--- a/src/app/ui/entries_list/mod.rs
+++ b/src/app/ui/entries_list/mod.rs
@@ -31,7 +31,7 @@ pub struct EntriesList {
     pub multi_select_mode: bool,
 }
 
-impl<'a> EntriesList {
+impl EntriesList {
     pub fn new() -> Self {
         Self {
             state: ListState::default(),
@@ -267,7 +267,7 @@ impl<'a> EntriesList {
         frame.render_widget(place_holder, area);
     }
 
-    fn get_list_block(&self, has_filter: bool, entries_len: Option<usize>) -> Block<'a> {
+    fn get_list_block<'a>(&self, has_filter: bool, entries_len: Option<usize>) -> Block<'a> {
         let title = match (self.multi_select_mode, has_filter) {
             (true, true) => "Journals - Multi-Select - Filtered",
             (true, false) => "Journals - Multi-Select",

--- a/src/app/ui/export_popup/mod.rs
+++ b/src/app/ui/export_popup/mod.rs
@@ -30,7 +30,7 @@ pub struct ExportPopup<'a> {
     paragraph_text: String,
 }
 
-impl<'a> ExportPopup<'a> {
+impl ExportPopup<'_> {
     pub fn create_entry_content<D: DataProvider>(
         entry: &Entry,
         app: &App<D>,

--- a/src/app/ui/filter_popup/mod.rs
+++ b/src/app/ui/filter_popup/mod.rs
@@ -42,7 +42,7 @@ enum FilterControl {
     TagsList,
 }
 
-impl<'a> FilterPopup<'a> {
+impl FilterPopup<'_> {
     pub fn new(tags: Vec<String>, filter: Option<Filter>) -> Self {
         let filter = filter.unwrap_or_default();
 

--- a/src/app/ui/fuzz_find/mod.rs
+++ b/src/app/ui/fuzz_find/mod.rs
@@ -44,7 +44,7 @@ impl FilteredEntry {
     }
 }
 
-impl<'a> FuzzFindPopup<'a> {
+impl FuzzFindPopup<'_> {
     pub fn new(entries: HashMap<u32, String>) -> Self {
         let mut query_text_box = TextArea::default();
         let block = Block::default().title("Search Query").borders(Borders::ALL);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,8 +5,8 @@ use std::{
 };
 
 use crate::{
-    logging::{get_default_path, setup_logging},
-    settings::{BackendType, Settings},
+    logging::{get_default_path as defaul_log_path, setup_logging},
+    settings::{settings_default_path, BackendType, Settings},
 };
 
 pub mod commands;
@@ -30,6 +30,9 @@ pub struct Cli {
     /// Sets the backend type and starts using it.
     #[arg(short, long, value_enum)]
     backend_type: Option<BackendType>,
+
+    #[arg(short = 'c', long = "config", value_name = "FLIE PAHT", help = config_help())]
+    pub config_path: Option<PathBuf>,
 
     /// write the current settings to config file (this will rewrite the whole config file)
     #[arg(short, long)]
@@ -72,7 +75,9 @@ impl Cli {
         }
 
         if self.write_config {
-            settings.write_current_settings().await?;
+            settings
+                .write_current_settings(self.config_path.clone())
+                .await?;
         }
 
         setup_logging(self.verbose, self.log_file)?;
@@ -123,7 +128,16 @@ fn set_backend_type(backend: BackendType, settings: &mut Settings) {
 fn log_help() -> String {
     format!(
         "Specifies a file to use for logging\n(default file: {})",
-        get_default_path()
+        defaul_log_path()
+            .map(|path| path.to_string_lossy().to_string())
+            .unwrap_or_default()
+    )
+}
+
+fn config_help() -> String {
+    format!(
+        "Specifies the path for the configuration file\n(default path: {})",
+        settings_default_path()
             .map(|path| path.to_string_lossy().to_string())
             .unwrap_or_default()
     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,9 +16,9 @@ mod settings;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let mut settings = Settings::new().await?;
-
     let cli = cli::Cli::parse();
+
+    let mut settings = Settings::new(cli.config_path.clone()).await?;
 
     let mut pending_cmd = None;
 

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -8,6 +8,8 @@ use serde::{
     Deserialize, Deserializer, Serialize,
 };
 
+use crate::app::state::AppState;
+
 #[cfg(feature = "json")]
 use self::json_backend::{get_default_json_path, JsonBackend};
 #[cfg(feature = "sqlite")]
@@ -52,6 +54,8 @@ pub struct Settings {
     #[serde(default)]
     /// Sets the visibility options for the datum of journals when rendered in entries list.
     pub datum_visibility: DatumVisibility,
+    /// Overwrite the path for the directory used to persist the app state.
+    pub app_state_dir: Option<PathBuf>,
 }
 
 impl Default for Settings {
@@ -70,6 +74,7 @@ impl Default for Settings {
             history_limit: default_history_limit(),
             colored_tags: default_colored_tags(),
             datum_visibility: Default::default(),
+            app_state_dir: Default::default(),
         }
     }
 }
@@ -158,6 +163,7 @@ impl Settings {
             history_limit: _,
             colored_tags: _,
             datum_visibility: _,
+            app_state_dir: _,
         } = self;
 
         if self.backend_type.is_none() {
@@ -176,6 +182,10 @@ impl Settings {
 
         if self.scroll_per_page.is_none() {
             self.scroll_per_page = Some(DEFAULT_SCROLL_PER_PAGE);
+        }
+
+        if self.app_state_dir.is_none() {
+            self.app_state_dir = Some(AppState::default_persist_dir()?);
         }
 
         Ok(())


### PR DESCRIPTION
This PR closes #504 

It provides the following:

* Change the default state directory on Linux and FreeBSD from `data` to `state` directories + Implement Moving the current states from the old directory to the new one.
* CLI argument to set the path for the configuration file.
* Add configuration to change the path of the state directory.
* Clippy Fixes
