### PR TITLE
Config for extension of temp file in external editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,9 @@ scroll_per_page = 5    # Sets how many journals will be scrolled using Page-Up a
 command = "nvim"
 # Enabling this save the journal content automatically after closing the external editor
 auto_save = false
+# Set the extension of the temporary file used with the external editor. 
+# This influences syntax highlighting in external editor (e.g., "md" for Markdown support).
+temp_file_extension = "txt"
 
 # Note: external_editor can still be configured in one line to set the command. In that case, the default values for the other fields will be used
 # external_editor = "nvim"

--- a/src/app/ui/commands/entries_list_cmd.rs
+++ b/src/app/ui/commands/entries_list_cmd.rs
@@ -293,9 +293,16 @@ pub async fn edit_in_external_editor<'a, D: DataProvider>(
     use tokio::fs;
 
     if let Some(entry) = app.get_current_entry() {
-        const FILE_NAME: &str = "tui_journal.txt";
+        const TEMP_FILENAME: &str = "tui_journal";
+        let temp_extension = &app.settings.external_editor.temp_file_extension;
 
-        let file_path = env::temp_dir().join(FILE_NAME);
+        let file_name = if !temp_extension.is_empty() {
+            format!("{TEMP_FILENAME}.{temp_extension}")
+        } else {
+            String::from(TEMP_FILENAME)
+        };
+
+        let file_path = env::temp_dir().join(file_name);
 
         if file_path.exists() {
             fs::remove_file(&file_path).await?;

--- a/src/settings/external_editor.rs
+++ b/src/settings/external_editor.rs
@@ -5,12 +5,28 @@ use serde::{Deserialize, Serialize};
 // In older version the external editor was a string only referring to the command.
 // To keep the configuration compatible, deserialize is implemented to accept either string or struct
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ExternalEditor {
     #[serde(default)]
     pub command: Option<String>,
     #[serde(default)]
     pub auto_save: bool,
+    #[serde(default = "default_temp_file_extension")]
+    pub temp_file_extension: String,
+}
+
+impl Default for ExternalEditor {
+    fn default() -> Self {
+        Self {
+            command: None,
+            auto_save: false,
+            temp_file_extension: default_temp_file_extension(),
+        }
+    }
+}
+
+fn default_temp_file_extension() -> String {
+    String::from("txt")
 }
 
 impl FromStr for ExternalEditor {


### PR DESCRIPTION
This PR closes #510 

It provides an option to set the extension of the temp file used with the external editor. 
This influences syntax highlighting in external editor (e.g., `md` for Markdown support).
 