### PR TITLE
Added: Custom themes on user level & Styles improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,6 +336,7 @@ dependencies = [
  "itoa",
  "rustversion",
  "ryu",
+ "serde",
  "static_assertions",
 ]
 
@@ -1796,6 +1797,7 @@ dependencies = [
  "itertools",
  "lru",
  "paste",
+ "serde",
  "strum",
  "time",
  "unicode-segmentation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ rayon = "1.10"
 fuzzy-matcher = "0.3"
 path-absolutize = "3.1"
 tui-textarea = "0.7"
-ratatui = { version = "0.29", features = ["all-widgets"]}
+ratatui = { version = "0.29", features = ["all-widgets", "serde"]}
 arboard = { version = "3.4", default-features = false, features = ["wayland-data-control"]}
 
 [features]

--- a/README.md
+++ b/README.md
@@ -47,9 +47,12 @@ TUI-Journal is a terminal-based application written in Rust that allows you to w
   - [Alpine Linux](#alpine-linux)
   - [FreeBSD](#freebsd)
   - [NetBSD](#netbsd)
-  - [Build & Install via Cargo ](#build--install-via-cargo)
+  - [Nix](#nix)
+  - [Homebrew](@homebrew)
+  - [Build & Install via Cargo](#build--install-via-cargo)
 - [Usage](#usage)
 - [Configuration](#configuration)
+- [Themes](#themes)
 - [Documentation](#documentation)
 - [Acknowledgments](#acknowledgments)
 - [Contributing](#contributing)
@@ -88,10 +91,10 @@ TUI-Journal is a terminal-based application written in Rust that allows you to w
 #### Application:
 - [x]  Edit journals content with external text editor from within the app.
 - [x]  Filter & Search functionalities.
-- [ ]  Add mouse support
+- [x]  Customize themes.
 - [ ]  Preview mode for journals supporting Mark Down highlighting and word wrapping.
+- [ ]  Add mouse support
 - [ ]  Improve app input and rending cycle using app events to support real concurrency within the app.
-- [ ]  Customize themes and keybindings.
 
       
 ## Installation
@@ -216,10 +219,11 @@ $ tjournal --help
 Usage: tjournal [OPTIONS] [COMMAND]
 
 Commands:
-  print-config  Print the current settings including the paths for the backend files [aliases: pc]
+  print-config     Print the current settings including the paths for the backend files [aliases: pc]
   import-journals  Import journals from the given transfer JSON file to the current back-end file [aliases: imj]
   assign-priority  Assign priority for all the entires with empty priority field [aliases: ap]
-  help          Print this message or the help of the given subcommand(s)
+  theme            Provides commands regarding changing themes and styles of the app [aliases: style]
+  help             Print this message or the help of the given subcommand(s)
 
 Options:
   -j, --json-file-path <FILE PATH>    Sets the entries Json file path and starts using it
@@ -288,6 +292,10 @@ file_path = "<Documents-folder>/tui-journal/entries.json"
 [sqlite_backend]
 file_path = "<Documents-folder>/tui-journal/entries.db"
 ```
+
+## Themes
+
+Please refer to the [Themes Page](THEMES.md) for a detailed guide on customizing colors and styles within the app.
 
 ## Documentation
 

--- a/THEMES.md
+++ b/THEMES.md
@@ -1,0 +1,128 @@
+# TUI-Journal Custom Themes:
+
+It's possible to override the styles used in the app or parts of them. Custom themes will be read from the file `theme.toml` in the configuration directory within the `tui-journal` directory.
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [Themes structures](#themes-structures)
+  - [Themes Groups](#themes-groups)
+  - [Themes Types](#themes-types)
+    - [Color Type](#color-type)
+    - [Style Type](#style-type)
+- [Example](#example)
+
+## Getting started:
+
+To get started, users can use the provided CLI subcommands under `tjournal theme`. These include specifying the path for the themes file, printing the default themes to be used as a base, or writing the themes directly into the themes file.
+
+```
+Provides commands regarding changing themes and styles of the app
+
+Usage: tjournal theme <COMMAND>
+
+Commands:
+  print-path      Prints the path to the user themes file [aliases: path]
+  print-default   Dumps the styles with the default values to be used as a reference and base for user custom themes [aliases: default]
+  write-defaults  Creates user custom themes file if doesn't exist then writes the default styles to it [aliases: write]
+  help            Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+```
+
+## Themes structures:
+
+### Themes Groups:
+
+Themes are divided into the following groups:
+- **general**: Styles for general controls in the app, including journal pop-ups, filter and sorting pop-ups, and more.
+- **journals_list**: Styles for the main list of journals. These styles are differentiated from the general ones since they are more important and contain more information than general list items.
+- **editor**: Styles for the built-in editor.
+- **msgbox**: Colors for message-box prompts (Questions, Errors, Warnings, etc.).
+
+### Themes Types:
+
+The main types used to define themes are `Color` and `Style`.
+
+#### Color Type
+
+Represents the color value of an item or field. It can be defined as a terminal color, such as `Black` or `Reset`, or as an RGB value in hexadecimal format `#RRGGBB`.
+
+#### Style Type
+
+Represents a complete style definition with the following fields:
+- **fg**: Foreground color.
+- **bg**: Background color.
+- **modifiers**: Modifiers change the way a piece of text is displayed. They are bitflags, so they can be easily combined.
+  The available modifiers are: `BOLD | DIM | ITALIC | UNDERLINED | SLOW_BLINK | RAPID_BLINK | REVERSED | HIDDEN | CROSSED_OUT`.
+- **underline_color**: The color of the underline parts if the `UNDERLINED` modifier is active.
+
+Here is an example of a style with all elements defined:
+
+```toml
+# Example of a style with all possible elements
+[example_style]
+fg = "#0AFA96" # Foreground Color. Colors can be in hex-decimal format "#RRGGBB"
+bg = "Black" # Background Color. Also it can be one of terminal colors.
+# Modifiers with all available flags. Flags can be combined as in example.
+modifiers = "BOLD | DIM | ITALIC | UNDERLINED | SLOW_BLINK | RAPID_BLINK | REVERSED | HIDDEN | CROSSED_OUT"
+underline_color = "Magenta" # Color for underline element if activated  
+```
+It's worth mentioning that not all fields must be defined. Missing parts will be filled with their default values.
+
+## Example:
+
+Here is a small example of overriding some of the themes. For a full list of all available style fields, please use the CLI subcommands to print the default themes.
+
+```toml
+[general]
+list_item_selected = { fg = "LightYellow", modifiers = "BOLD" }
+input_block_active = { fg = "Blue" }
+
+[general.input_block_invalid]
+fg = "Red"
+modifiers = "BOLD | SLOW_BLINK"
+
+[general.input_corsur_active]
+fg = "Black"
+bg = "LightYellow"
+modifiers = "RAPID_BLINK"
+
+[general.list_highlight_active]
+fg = "Black"
+bg = "LightGreen"
+modifiers = "UNDERLINED"
+underline_color = "Magenta"
+
+[journals_list.block_inactive]
+fg = "Grey"
+modifiers = ""
+
+[journals_list.highlight_active]
+fg = "Red"
+bg = "LightGreen"
+modifiers = "BOLD | ITALIC"
+
+[journals_list.highlight_inactive]
+fg = "Grey"
+bg = "LightBlue"
+modifiers = "BOLD"
+
+[journals_list.title_active]
+fg = "Reset"
+modifiers = "BOLD | UNDERLINED"
+
+[editor.block_insert]
+fg = "LightGreen"
+modifiers = "BOLD"
+
+[editor.cursor_insert]
+fg = "Green"
+bg = "LightGreen"
+modifiers = "RAPID_BLINK"
+
+[msgbox]
+error = "#105577"
+question = "Magenta"
+```

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -26,7 +26,7 @@ mod sorter;
 pub mod state;
 #[cfg(test)]
 mod test;
-mod ui;
+pub mod ui;
 
 pub use runner::run;
 pub use runner::HandleInputReturnType;

--- a/src/app/runner.rs
+++ b/src/app/runner.rs
@@ -75,7 +75,7 @@ where
     B: Backend,
     D: DataProvider,
 {
-    let mut ui_components = UIComponents::new();
+    let mut ui_components = UIComponents::new()?;
     let mut app = App::new(data_provider, settings);
     if let Some(cmd) = pending_cmd {
         if let Err(err) = exec_pending_cmd(terminal, &app, cmd).await {

--- a/src/app/runner.rs
+++ b/src/app/runner.rs
@@ -15,6 +15,7 @@ use backend::SqliteDataProvide;
 
 use super::keymap::Input;
 use super::ui::ui_functions::render_message_centered;
+use super::ui::Styles;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum HandleInputReturnType {
@@ -27,6 +28,7 @@ pub enum HandleInputReturnType {
 pub async fn run<B: Backend>(
     terminal: &mut Terminal<B>,
     settings: Settings,
+    styles: Styles,
     pending_cmd: Option<PendingCliCommand>,
 ) -> Result<()> {
     match settings.backend_type.unwrap_or_default() {
@@ -38,7 +40,7 @@ pub async fn run<B: Backend>(
                 crate::settings::json_backend::get_default_json_path()?
             };
             let data_provider = JsonDataProvide::new(path);
-            run_intern(terminal, data_provider, settings, pending_cmd).await
+            run_intern(terminal, data_provider, settings, styles, pending_cmd).await
         }
         #[cfg(not(feature = "json"))]
         BackendType::Json => {
@@ -54,7 +56,7 @@ pub async fn run<B: Backend>(
                 crate::settings::sqlite_backend::get_default_sqlite_path()?
             };
             let data_provider = SqliteDataProvide::from_file(path).await?;
-            run_intern(terminal, data_provider, settings, pending_cmd).await
+            run_intern(terminal, data_provider, settings, styles, pending_cmd).await
         }
         #[cfg(not(feature = "sqlite"))]
         BackendType::Sqlite => {
@@ -69,13 +71,14 @@ async fn run_intern<B, D>(
     terminal: &mut Terminal<B>,
     data_provider: D,
     settings: Settings,
+    styles: Styles,
     pending_cmd: Option<PendingCliCommand>,
 ) -> anyhow::Result<()>
 where
     B: Backend,
     D: DataProvider,
 {
-    let mut ui_components = UIComponents::new()?;
+    let mut ui_components = UIComponents::new(styles);
     let mut app = App::new(data_provider, settings);
     if let Some(cmd) = pending_cmd {
         if let Err(err) = exec_pending_cmd(terminal, &app, cmd).await {

--- a/src/app/ui/export_popup/mod.rs
+++ b/src/app/ui/export_popup/mod.rs
@@ -12,10 +12,7 @@ use tui_textarea::{CursorMove, TextArea};
 
 use crate::app::{keymap::Input, App};
 
-use super::{
-    ui_functions::centered_rect_exact_height, PopupReturn, ACTIVE_CONTROL_COLOR,
-    INVALID_CONTROL_COLOR,
-};
+use super::{ui_functions::centered_rect_exact_height, PopupReturn, Styles};
 
 type ExportPopupInputReturn = PopupReturn<(PathBuf, Option<u32>)>;
 
@@ -117,7 +114,7 @@ impl ExportPopup<'_> {
         self.entry_id.is_none()
     }
 
-    pub fn render_widget(&mut self, frame: &mut Frame, area: Rect) {
+    pub fn render_widget(&mut self, frame: &mut Frame, area: Rect, styles: &Styles) {
         let mut area = centered_rect_exact_height(70, 11, area);
 
         if area.width < FOOTER_TEXT.len() as u16 + FOOTER_MARGINE {
@@ -155,21 +152,25 @@ impl ExportPopup<'_> {
         frame.render_widget(journal_paragraph, chunks[0]);
 
         if self.path_err_msg.is_empty() {
-            let active_color = Style::default().fg(ACTIVE_CONTROL_COLOR);
-            self.path_txt.set_style(active_color);
+            let block = Style::from(styles.general.input_block_active);
+            let cursor = Style::from(styles.general.input_corsur_active);
+            self.path_txt.set_style(block);
+            self.path_txt.set_cursor_style(cursor);
             self.path_txt.set_block(
                 Block::default()
                     .borders(Borders::ALL)
-                    .style(active_color)
+                    .style(block)
                     .title("Path"),
             );
         } else {
-            let invalide_style = Style::default().fg(INVALID_CONTROL_COLOR);
-            self.path_txt.set_style(invalide_style);
+            let block = Style::from(styles.general.input_block_invalid);
+            let cursor = Style::from(styles.general.input_corsur_invalid);
+            self.path_txt.set_style(block);
+            self.path_txt.set_cursor_style(cursor);
             self.path_txt.set_block(
                 Block::default()
                     .borders(Borders::ALL)
-                    .style(invalide_style)
+                    .style(block)
                     .title(format!("Path : {}", self.path_err_msg)),
             );
         }

--- a/src/app/ui/fuzz_find/mod.rs
+++ b/src/app/ui/fuzz_find/mod.rs
@@ -13,7 +13,7 @@ use tui_textarea::TextArea;
 
 use crate::app::keymap::Input;
 
-use super::ui_functions::centered_rect;
+use super::{ui_functions::centered_rect, Styles};
 
 const FOOTER_TEXT: &str = "Esc, Enter, <Ctrl-m>, <Ctrl-c>: Close | Up, Down, <Ctrl-n>, <Ctrl-p>: cycle through filtered list";
 const FOOTER_MARGINE: usize = 8;
@@ -61,7 +61,7 @@ impl FuzzFindPopup<'_> {
         }
     }
 
-    pub fn render_widget(&mut self, frame: &mut Frame, area: Rect) {
+    pub fn render_widget(&mut self, frame: &mut Frame, area: Rect, styles: &Styles) {
         let area = centered_rect(60, 60, area);
 
         let block = Block::default()
@@ -92,12 +92,12 @@ impl FuzzFindPopup<'_> {
 
         frame.render_widget(&self.query_text_box, chunks[0]);
 
-        self.render_entries_list(frame, chunks[1]);
+        self.render_entries_list(frame, chunks[1], styles);
 
         self.render_footer(frame, chunks[2]);
     }
 
-    fn render_entries_list(&mut self, frame: &mut Frame, area: Rect) {
+    fn render_entries_list(&mut self, frame: &mut Frame, area: Rect, styles: &Styles) {
         let items: Vec<ListItem> = self
             .filtered_entries
             .iter()
@@ -134,7 +134,7 @@ impl FuzzFindPopup<'_> {
 
         let list = List::new(items)
             .block(block)
-            .highlight_style(Style::default().fg(Color::Black).bg(Color::LightGreen))
+            .highlight_style(styles.general.list_highlight_active)
             .highlight_symbol(">> ");
 
         frame.render_stateful_widget(list, area, &mut self.list_state);

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -28,7 +28,6 @@ use anyhow::Result;
 
 use ratatui::{
     layout::{Constraint, Direction, Layout},
-    style::Color,
     Frame,
 };
 
@@ -48,10 +47,6 @@ pub mod ui_functions;
 
 pub use commands::UICommand;
 pub use msg_box::MsgBoxResult;
-
-pub const ACTIVE_CONTROL_COLOR: Color = Color::Reset;
-pub const INACTIVE_CONTROL_COLOR: Color = Color::Rgb(170, 170, 200);
-pub const INVALID_CONTROL_COLOR: Color = Color::LightRed;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ControlType {
@@ -191,7 +186,7 @@ impl<'a, 'b> UIComponents<'a> {
                     filter_popup.render_widget(f, f.area(), &self.styles)
                 }
                 Popup::FuzzFind(fuzz_find) => fuzz_find.render_widget(f, f.area(), &self.styles),
-                Popup::Sort(sort_popup) => sort_popup.render_widget(f, f.area()),
+                Popup::Sort(sort_popup) => sort_popup.render_widget(f, f.area(), &self.styles),
             }
         }
     }

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -178,7 +178,7 @@ impl<'a, 'b> UIComponents<'a> {
             match popup {
                 Popup::Help(help_popup) => help_popup.render_widget(f, f.area()),
                 Popup::Entry(entry_popup) => entry_popup.render_widget(f, f.area(), &self.styles),
-                Popup::MsgBox(msg_box) => msg_box.render_widget(f, f.area()),
+                Popup::MsgBox(msg_box) => msg_box.render_widget(f, f.area(), &self.styles),
                 Popup::Export(export_popup) => {
                     export_popup.render_widget(f, f.area(), &self.styles)
                 }

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -24,7 +24,7 @@ use super::{
     runner::HandleInputReturnType,
     App,
 };
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use ratatui::{
     layout::{Constraint, Direction, Layout},
@@ -85,9 +85,8 @@ pub struct UIComponents<'a> {
 }
 
 impl<'a, 'b> UIComponents<'a> {
-    pub fn new() -> Self {
-        // TODO: I'm using defaults for now. This needs to be read from themes files
-        let styles = Styles::default();
+    pub fn new() -> anyhow::Result<Self> {
+        let styles = Styles::load().context("Error while retrieving app styles")?;
 
         let global_keymaps = get_global_keymaps();
         let entries_list_keymaps = get_entries_list_keymaps();
@@ -99,7 +98,7 @@ impl<'a, 'b> UIComponents<'a> {
         let active_control = ControlType::EntriesList;
         entries_list.set_active(true);
 
-        Self {
+        let ui = Self {
             styles,
             global_keymaps,
             entries_list_keymaps,
@@ -110,7 +109,9 @@ impl<'a, 'b> UIComponents<'a> {
             popup_stack: Vec::new(),
             active_control,
             pending_command: None,
-        }
+        };
+
+        Ok(ui)
     }
 
     pub fn has_popup(&self) -> bool {

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -185,7 +185,9 @@ impl<'a, 'b> UIComponents<'a> {
                 Popup::Entry(entry_popup) => entry_popup.render_widget(f, f.area()),
                 Popup::MsgBox(msg_box) => msg_box.render_widget(f, f.area()),
                 Popup::Export(export_popup) => export_popup.render_widget(f, f.area()),
-                Popup::Filter(filter_popup) => filter_popup.render_widget(f, f.area()),
+                Popup::Filter(filter_popup) => {
+                    filter_popup.render_widget(f, f.area(), &self.styles)
+                }
                 Popup::FuzzFind(fuzz_find) => fuzz_find.render_widget(f, f.area()),
                 Popup::Sort(sort_popup) => sort_popup.render_widget(f, f.area()),
             }

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -24,7 +24,7 @@ use super::{
     runner::HandleInputReturnType,
     App,
 };
-use anyhow::{Context, Result};
+use anyhow::Result;
 
 use ratatui::{
     layout::{Constraint, Direction, Layout},
@@ -85,9 +85,7 @@ pub struct UIComponents<'a> {
 }
 
 impl<'a, 'b> UIComponents<'a> {
-    pub fn new() -> anyhow::Result<Self> {
-        let styles = Styles::load().context("Error while retrieving app styles")?;
-
+    pub fn new(styles: Styles) -> Self {
         let global_keymaps = get_global_keymaps();
         let entries_list_keymaps = get_entries_list_keymaps();
         let editor_keymaps = get_editor_mode_keymaps();
@@ -98,7 +96,7 @@ impl<'a, 'b> UIComponents<'a> {
         let active_control = ControlType::EntriesList;
         entries_list.set_active(true);
 
-        let ui = Self {
+        Self {
             styles,
             global_keymaps,
             entries_list_keymaps,
@@ -109,9 +107,7 @@ impl<'a, 'b> UIComponents<'a> {
             popup_stack: Vec::new(),
             active_control,
             pending_command: None,
-        };
-
-        Ok(ui)
+        }
     }
 
     pub fn has_popup(&self) -> bool {

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -182,7 +182,7 @@ impl<'a, 'b> UIComponents<'a> {
         if let Some(popup) = self.popup_stack.last_mut() {
             match popup {
                 Popup::Help(help_popup) => help_popup.render_widget(f, f.area()),
-                Popup::Entry(entry_popup) => entry_popup.render_widget(f, f.area()),
+                Popup::Entry(entry_popup) => entry_popup.render_widget(f, f.area(), &self.styles),
                 Popup::MsgBox(msg_box) => msg_box.render_widget(f, f.area()),
                 Popup::Export(export_popup) => export_popup.render_widget(f, f.area()),
                 Popup::Filter(filter_popup) => {

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -184,11 +184,13 @@ impl<'a, 'b> UIComponents<'a> {
                 Popup::Help(help_popup) => help_popup.render_widget(f, f.area()),
                 Popup::Entry(entry_popup) => entry_popup.render_widget(f, f.area(), &self.styles),
                 Popup::MsgBox(msg_box) => msg_box.render_widget(f, f.area()),
-                Popup::Export(export_popup) => export_popup.render_widget(f, f.area()),
+                Popup::Export(export_popup) => {
+                    export_popup.render_widget(f, f.area(), &self.styles)
+                }
                 Popup::Filter(filter_popup) => {
                     filter_popup.render_widget(f, f.area(), &self.styles)
                 }
-                Popup::FuzzFind(fuzz_find) => fuzz_find.render_widget(f, f.area()),
+                Popup::FuzzFind(fuzz_find) => fuzz_find.render_widget(f, f.area(), &self.styles),
                 Popup::Sort(sort_popup) => sort_popup.render_widget(f, f.area()),
             }
         }

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -147,8 +147,13 @@ impl<'a, 'b> UIComponents<'a> {
         if app.state.full_screen {
             match self.active_control {
                 ControlType::EntriesList => {
-                    self.entries_list
-                        .render_widget(f, chunks[0], app, &self.entries_list_keymaps);
+                    self.entries_list.render_widget(
+                        f,
+                        chunks[0],
+                        app,
+                        &self.entries_list_keymaps,
+                        &self.styles,
+                    );
                 }
                 ControlType::EntryContentTxt => {
                     self.editor.render_widget(f, chunks[0], &self.styles);
@@ -159,8 +164,13 @@ impl<'a, 'b> UIComponents<'a> {
                 .direction(Direction::Horizontal)
                 .constraints([Constraint::Percentage(30), Constraint::Percentage(70)].as_ref())
                 .split(chunks[0]);
-            self.entries_list
-                .render_widget(f, entries_chunks[0], app, &self.entries_list_keymaps);
+            self.entries_list.render_widget(
+                f,
+                entries_chunks[0],
+                app,
+                &self.entries_list_keymaps,
+                &self.styles,
+            );
             self.editor
                 .render_widget(f, entries_chunks[1], &self.styles);
         }

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use backend::DataProvider;
+pub use themes::Styles;
 
 use self::{
     editor::{Editor, EditorMode},
@@ -50,9 +51,7 @@ pub use msg_box::MsgBoxResult;
 
 pub const ACTIVE_CONTROL_COLOR: Color = Color::Reset;
 pub const INACTIVE_CONTROL_COLOR: Color = Color::Rgb(170, 170, 200);
-pub const EDITOR_MODE_COLOR: Color = Color::LightGreen;
 pub const INVALID_CONTROL_COLOR: Color = Color::LightRed;
-pub const VISUAL_MODE_COLOR: Color = Color::Blue;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ControlType {
@@ -78,6 +77,7 @@ pub enum PopupReturn<T> {
 }
 
 pub struct UIComponents<'a> {
+    styles: Styles,
     global_keymaps: Vec<Keymap>,
     entries_list_keymaps: Vec<Keymap>,
     editor_keymaps: Vec<Keymap>,
@@ -91,6 +91,9 @@ pub struct UIComponents<'a> {
 
 impl<'a, 'b> UIComponents<'a> {
     pub fn new() -> Self {
+        // TODO: I'm using defaults for now. This needs to be read from themes files
+        let styles = Styles::default();
+
         let global_keymaps = get_global_keymaps();
         let entries_list_keymaps = get_entries_list_keymaps();
         let editor_keymaps = get_editor_mode_keymaps();
@@ -102,6 +105,7 @@ impl<'a, 'b> UIComponents<'a> {
         entries_list.set_active(true);
 
         Self {
+            styles,
             global_keymaps,
             entries_list_keymaps,
             editor_keymaps,
@@ -147,7 +151,7 @@ impl<'a, 'b> UIComponents<'a> {
                         .render_widget(f, chunks[0], app, &self.entries_list_keymaps);
                 }
                 ControlType::EntryContentTxt => {
-                    self.editor.render_widget(f, chunks[0]);
+                    self.editor.render_widget(f, chunks[0], &self.styles);
                 }
             }
         } else {
@@ -157,7 +161,8 @@ impl<'a, 'b> UIComponents<'a> {
                 .split(chunks[0]);
             self.entries_list
                 .render_widget(f, entries_chunks[0], app, &self.entries_list_keymaps);
-            self.editor.render_widget(f, entries_chunks[1]);
+            self.editor
+                .render_widget(f, entries_chunks[1], &self.styles);
         }
 
         self.render_popup(f);

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -42,6 +42,7 @@ mod fuzz_find;
 mod help_popup;
 mod msg_box;
 mod sort_popup;
+pub mod themes;
 pub mod ui_functions;
 
 pub use commands::UICommand;

--- a/src/app/ui/msg_box/mod.rs
+++ b/src/app/ui/msg_box/mod.rs
@@ -1,7 +1,7 @@
 use crossterm::event::KeyCode;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Style},
+    style::Style,
     text::Span,
     widgets::{Block, Borders, Clear, Paragraph, Wrap},
     Frame,
@@ -9,7 +9,7 @@ use ratatui::{
 
 use crate::app::keymap::Input;
 
-use super::ui_functions::centered_rect_exact_height;
+use super::{ui_functions::centered_rect_exact_height, Styles};
 
 // Not all enums are used in this app at this point
 #[allow(dead_code)]
@@ -56,14 +56,16 @@ impl MsgBox {
         Self { msg_type, actions }
     }
 
-    pub fn render_widget(&mut self, frame: &mut Frame, area: Rect) {
+    pub fn render_widget(&mut self, frame: &mut Frame, area: Rect, styles: &Styles) {
         let area = centered_rect_exact_height(55, 8, area);
 
+        let colors = &styles.msgbox;
+
         let (title, color, text) = match &self.msg_type {
-            MsgBoxType::Error(text) => ("Error", Color::LightRed, text),
-            MsgBoxType::Warning(text) => ("Warning", Color::Yellow, text),
-            MsgBoxType::Info(text) => ("Info", Color::LightGreen, text),
-            MsgBoxType::Question(text) => ("", Color::LightBlue, text),
+            MsgBoxType::Error(text) => ("Error", colors.error, text),
+            MsgBoxType::Warning(text) => ("Warning", colors.warning, text),
+            MsgBoxType::Info(text) => ("Info", colors.info, text),
+            MsgBoxType::Question(text) => ("", colors.question, text),
         };
 
         let border = Block::default()

--- a/src/app/ui/themes/editor_styles.rs
+++ b/src/app/ui/themes/editor_styles.rs
@@ -3,76 +3,108 @@ use serde::{Deserialize, Serialize};
 
 use super::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EditorStyles {
+    #[serde(default = "block_insert")]
     pub block_insert: Style,
+    #[serde(default = "block_visual")]
     pub block_visual: Style,
+    #[serde(default = "block_normal_active")]
     pub block_normal_active: Style,
+    #[serde(default = "block_normal_inactive")]
     pub block_normal_inactive: Style,
+    #[serde(default = "cursor_normal")]
     pub cursor_normal: Style,
+    #[serde(default = "cursor_insert")]
     pub cursor_insert: Style,
+    #[serde(default = "cursor_visual")]
     pub cursor_visual: Style,
+    #[serde(default = "selection_style")]
     pub selection_style: Style,
 }
 
 impl Default for EditorStyles {
     fn default() -> Self {
-        let block_insert = Style {
-            fg: Some(EDITOR_MODE_COLOR),
-            modifiers: Modifier::BOLD,
-            ..Default::default()
-        };
-
-        let block_visual = Style {
-            fg: Some(VISUAL_MODE_COLOR),
-            modifiers: Modifier::BOLD,
-            ..Default::default()
-        };
-
-        let block_normal_active = Style {
-            fg: Some(ACTIVE_CONTROL_COLOR),
-            modifiers: Modifier::BOLD,
-            ..Default::default()
-        };
-
-        let block_normal_inactive = Style {
-            fg: Some(INACTIVE_CONTROL_COLOR),
-            ..Default::default()
-        };
-
-        let cursor_normal = Style {
-            fg: Some(Color::Black),
-            bg: Some(Color::White),
-            ..Default::default()
-        };
-
-        let cursor_insert = Style {
-            fg: Some(Color::Black),
-            bg: Some(EDITOR_MODE_COLOR),
-            ..Default::default()
-        };
-
-        let cursor_visual = Style {
-            fg: Some(Color::Black),
-            bg: Some(VISUAL_MODE_COLOR),
-            ..Default::default()
-        };
-
-        let selection_style = Style {
-            fg: Some(Color::Black),
-            bg: Some(Color::White),
-            ..Default::default()
-        };
-
         Self {
-            block_insert,
-            block_visual,
-            block_normal_active,
-            block_normal_inactive,
-            cursor_normal,
-            cursor_insert,
-            cursor_visual,
-            selection_style,
+            block_insert: block_insert(),
+            block_visual: block_visual(),
+            block_normal_active: block_normal_active(),
+            block_normal_inactive: block_normal_inactive(),
+            cursor_normal: cursor_normal(),
+            cursor_insert: cursor_insert(),
+            cursor_visual: cursor_visual(),
+            selection_style: selection_style(),
         }
+    }
+}
+
+#[inline]
+fn block_insert() -> Style {
+    Style {
+        fg: Some(EDITOR_MODE_COLOR),
+        modifiers: Modifier::BOLD,
+        ..Default::default()
+    }
+}
+
+#[inline]
+fn block_visual() -> Style {
+    Style {
+        fg: Some(VISUAL_MODE_COLOR),
+        modifiers: Modifier::BOLD,
+        ..Default::default()
+    }
+}
+
+#[inline]
+fn block_normal_active() -> Style {
+    Style {
+        fg: Some(ACTIVE_CONTROL_COLOR),
+        modifiers: Modifier::BOLD,
+        ..Default::default()
+    }
+}
+
+#[inline]
+fn block_normal_inactive() -> Style {
+    Style {
+        fg: Some(INACTIVE_CONTROL_COLOR),
+        ..Default::default()
+    }
+}
+
+#[inline]
+fn cursor_normal() -> Style {
+    Style {
+        fg: Some(Color::Black),
+        bg: Some(Color::White),
+        ..Default::default()
+    }
+}
+
+#[inline]
+fn cursor_insert() -> Style {
+    Style {
+        fg: Some(Color::Black),
+        bg: Some(EDITOR_MODE_COLOR),
+        ..Default::default()
+    }
+}
+
+#[inline]
+fn cursor_visual() -> Style {
+    Style {
+        fg: Some(Color::Black),
+        bg: Some(VISUAL_MODE_COLOR),
+        ..Default::default()
+    }
+}
+
+#[inline]
+fn selection_style() -> Style {
+    Style {
+        fg: Some(Color::Black),
+        bg: Some(Color::White),
+        ..Default::default()
     }
 }

--- a/src/app/ui/themes/editor_styles.rs
+++ b/src/app/ui/themes/editor_styles.rs
@@ -1,0 +1,78 @@
+use ratatui::style::Modifier;
+use serde::{Deserialize, Serialize};
+
+use super::*;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EditorStyles {
+    pub block_insert: Style,
+    pub block_visual: Style,
+    pub block_normal_active: Style,
+    pub block_normal_inactive: Style,
+    pub cursor_normal: Style,
+    pub cursor_insert: Style,
+    pub cursor_visual: Style,
+    pub selection_style: Style,
+}
+
+impl Default for EditorStyles {
+    fn default() -> Self {
+        let block_insert = Style {
+            fg: Some(EDITOR_MODE_COLOR),
+            modifiers: Modifier::BOLD,
+            ..Default::default()
+        };
+
+        let block_visual = Style {
+            fg: Some(VISUAL_MODE_COLOR),
+            modifiers: Modifier::BOLD,
+            ..Default::default()
+        };
+
+        let block_normal_active = Style {
+            fg: Some(ACTIVE_CONTROL_COLOR),
+            modifiers: Modifier::BOLD,
+            ..Default::default()
+        };
+
+        let block_normal_inactive = Style {
+            fg: Some(INACTIVE_CONTROL_COLOR),
+            ..Default::default()
+        };
+
+        let cursor_normal = Style {
+            fg: Some(Color::Black),
+            bg: Some(Color::White),
+            ..Default::default()
+        };
+
+        let cursor_insert = Style {
+            fg: Some(Color::Black),
+            bg: Some(EDITOR_MODE_COLOR),
+            ..Default::default()
+        };
+
+        let cursor_visual = Style {
+            fg: Some(Color::Black),
+            bg: Some(VISUAL_MODE_COLOR),
+            ..Default::default()
+        };
+
+        let selection_style = Style {
+            fg: Some(Color::Black),
+            bg: Some(Color::White),
+            ..Default::default()
+        };
+
+        Self {
+            block_insert,
+            block_visual,
+            block_normal_active,
+            block_normal_inactive,
+            cursor_normal,
+            cursor_insert,
+            cursor_visual,
+            selection_style,
+        }
+    }
+}

--- a/src/app/ui/themes/general_styles.rs
+++ b/src/app/ui/themes/general_styles.rs
@@ -3,66 +3,95 @@ use serde::{Deserialize, Serialize};
 
 use super::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GeneralStyles {
     // input text
+    #[serde(default = "input_block_active")]
     pub input_block_active: Style,
+    #[serde(default = "input_block_invalid")]
     pub input_block_invalid: Style,
+    #[serde(default = "input_corsur_active")]
     pub input_corsur_active: Style,
+    #[serde(default = "input_corsur_invalid")]
     pub input_corsur_invalid: Style,
 
     // General list items
+    #[serde(default = "list_item_selected")]
     pub list_item_selected: Style,
+    #[serde(default = "list_highlight_active")]
     pub list_highlight_active: Style,
+    #[serde(default = "list_highlight_inactive")]
     pub list_highlight_inactive: Style,
 }
 
 impl Default for GeneralStyles {
     fn default() -> Self {
-        let input_block_invalid = Style {
-            fg: Some(INVALID_CONTROL_COLOR),
-            ..Default::default()
-        };
-        let input_block_active = Style {
-            fg: Some(ACTIVE_INPUT_BORDER_COLOR),
-            ..Default::default()
-        };
-        let input_corsur_active = Style {
-            bg: Some(ACTIVE_INPUT_BORDER_COLOR),
-            fg: Some(Color::Black),
-            ..Default::default()
-        };
-        let input_corsur_invalid = Style {
-            bg: Some(INVALID_CONTROL_COLOR),
-            fg: Some(Color::Black),
-            ..Default::default()
-        };
-
-        let list_item_selected = Style {
-            fg: Some(Color::LightYellow),
-            modifiers: Modifier::BOLD,
-            ..Default::default()
-        };
-        let list_highlight_active = Style {
-            fg: Some(Color::Black),
-            bg: Some(Color::LightGreen),
-            ..Default::default()
-        };
-
-        let list_highlight_inactive = Style {
-            fg: Some(Color::Black),
-            bg: Some(Color::LightBlue),
-            ..Default::default()
-        };
-
         Self {
-            input_block_active,
-            input_block_invalid,
-            input_corsur_active,
-            input_corsur_invalid,
-            list_item_selected,
-            list_highlight_active,
-            list_highlight_inactive,
+            input_block_active: input_block_active(),
+            input_block_invalid: input_block_invalid(),
+            input_corsur_active: input_corsur_active(),
+            input_corsur_invalid: input_corsur_invalid(),
+            list_item_selected: list_item_selected(),
+            list_highlight_active: list_highlight_active(),
+            list_highlight_inactive: list_highlight_inactive(),
         }
+    }
+}
+
+#[inline]
+fn input_block_invalid() -> Style {
+    Style {
+        fg: Some(INVALID_CONTROL_COLOR),
+        ..Default::default()
+    }
+}
+
+#[inline]
+fn input_block_active() -> Style {
+    Style {
+        fg: Some(ACTIVE_INPUT_BORDER_COLOR),
+        ..Default::default()
+    }
+}
+
+#[inline]
+fn input_corsur_active() -> Style {
+    Style {
+        bg: Some(ACTIVE_INPUT_BORDER_COLOR),
+        fg: Some(Color::Black),
+        ..Default::default()
+    }
+}
+
+#[inline]
+fn input_corsur_invalid() -> Style {
+    Style {
+        bg: Some(INVALID_CONTROL_COLOR),
+        fg: Some(Color::Black),
+        ..Default::default()
+    }
+}
+
+#[inline]
+fn list_item_selected() -> Style {
+    Style {
+        fg: Some(Color::LightYellow),
+        modifiers: Modifier::BOLD,
+        ..Default::default()
+    }
+}
+fn list_highlight_active() -> Style {
+    Style {
+        fg: Some(Color::Black),
+        bg: Some(Color::LightGreen),
+        ..Default::default()
+    }
+}
+
+fn list_highlight_inactive() -> Style {
+    Style {
+        fg: Some(Color::Black),
+        bg: Some(Color::LightBlue),
+        ..Default::default()
     }
 }

--- a/src/app/ui/themes/general_styles.rs
+++ b/src/app/ui/themes/general_styles.rs
@@ -1,0 +1,68 @@
+use ratatui::style::Modifier;
+use serde::{Deserialize, Serialize};
+
+use super::*;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GeneralStyles {
+    // input text
+    pub input_block_active: Style,
+    pub input_block_invalid: Style,
+    pub input_corsur_active: Style,
+    pub input_corsur_invalid: Style,
+
+    // General list items
+    pub list_item_selected: Style,
+    pub list_highlight_active: Style,
+    pub list_highlight_inactive: Style,
+}
+
+impl Default for GeneralStyles {
+    fn default() -> Self {
+        let input_block_invalid = Style {
+            fg: Some(INVALID_CONTROL_COLOR),
+            ..Default::default()
+        };
+        let input_block_active = Style {
+            fg: Some(ACTIVE_INPUT_BORDER_COLOR),
+            ..Default::default()
+        };
+        let input_corsur_active = Style {
+            bg: Some(ACTIVE_INPUT_BORDER_COLOR),
+            fg: Some(Color::Black),
+            ..Default::default()
+        };
+        let input_corsur_invalid = Style {
+            bg: Some(INVALID_CONTROL_COLOR),
+            fg: Some(Color::Black),
+            ..Default::default()
+        };
+
+        let list_item_selected = Style {
+            fg: Some(Color::LightYellow),
+            modifiers: Modifier::BOLD,
+            ..Default::default()
+        };
+        let list_highlight_active = Style {
+            fg: Some(Color::Black),
+            bg: Some(Color::LightGreen),
+            ..Default::default()
+        };
+
+        let list_highlight_inactive = Style {
+            fg: Some(Color::Black),
+            bg: Some(Color::LightBlue),
+            ..Default::default()
+        };
+
+        Self {
+            input_block_active,
+            input_block_invalid,
+            input_corsur_active,
+            input_corsur_invalid,
+            list_item_selected,
+            list_highlight_active,
+            list_highlight_inactive,
+        }
+    }
+}

--- a/src/app/ui/themes/journals_list_styles.rs
+++ b/src/app/ui/themes/journals_list_styles.rs
@@ -1,0 +1,94 @@
+use ratatui::style::Modifier;
+use serde::{Deserialize, Serialize};
+
+use crate::app::ui::{ACTIVE_CONTROL_COLOR, INACTIVE_CONTROL_COLOR};
+
+use super::*;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JournalsListStyles {
+    pub block_active: Style,
+    pub block_inactive: Style,
+    pub block_multi_select: Style,
+    pub highlight_active: Style,
+    pub highlight_inactive: Style,
+    pub title_active: Style,
+    pub title_inactive: Style,
+    /// Styles when item is marked as selected in select mode
+    pub title_selected: Style,
+    pub date_priority: Style,
+    pub tags_default: Style,
+}
+
+impl Default for JournalsListStyles {
+    fn default() -> Self {
+        let block_active = Style {
+            fg: Some(ACTIVE_CONTROL_COLOR),
+            modifiers: Modifier::BOLD,
+            ..Default::default()
+        };
+        let block_inactive = Style {
+            fg: Some(INACTIVE_CONTROL_COLOR),
+            ..Default::default()
+        };
+        let block_multi_select = Style {
+            fg: Some(SELECTED_FOREGROUND_COLOR),
+            modifiers: Modifier::BOLD | Modifier::ITALIC,
+            ..Default::default()
+        };
+
+        let highlight_active = Style {
+            fg: Some(Color::Black),
+            bg: Some(Color::LightGreen),
+            modifiers: Modifier::BOLD,
+            ..Default::default()
+        };
+
+        let highlight_inactive = Style {
+            fg: Some(Color::Black),
+            bg: Some(Color::LightBlue),
+            modifiers: Modifier::BOLD,
+            ..Default::default()
+        };
+
+        let title_active = Style {
+            fg: Some(ACTIVE_CONTROL_COLOR),
+            modifiers: Modifier::BOLD,
+            ..Default::default()
+        };
+        let title_inactive = Style {
+            fg: Some(INACTIVE_CONTROL_COLOR),
+            modifiers: Modifier::BOLD,
+            ..Default::default()
+        };
+        let title_selected = Style {
+            fg: Some(SELECTED_FOREGROUND_COLOR),
+            modifiers: Modifier::BOLD,
+            ..Default::default()
+        };
+
+        let date_priority = Style {
+            fg: Some(Color::LightBlue),
+            ..Default::default()
+        };
+
+        let tags_default = Style {
+            fg: Some(Color::LightCyan),
+            modifiers: Modifier::DIM,
+            ..Default::default()
+        };
+
+        Self {
+            block_active,
+            block_inactive,
+            block_multi_select,
+            highlight_active,
+            highlight_inactive,
+            title_active,
+            title_inactive,
+            title_selected,
+            date_priority,
+            tags_default,
+        }
+    }
+}

--- a/src/app/ui/themes/journals_list_styles.rs
+++ b/src/app/ui/themes/journals_list_styles.rs
@@ -1,8 +1,6 @@
 use ratatui::style::Modifier;
 use serde::{Deserialize, Serialize};
 
-use crate::app::ui::{ACTIVE_CONTROL_COLOR, INACTIVE_CONTROL_COLOR};
-
 use super::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/app/ui/themes/journals_list_styles.rs
+++ b/src/app/ui/themes/journals_list_styles.rs
@@ -3,90 +3,134 @@ use serde::{Deserialize, Serialize};
 
 use super::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct JournalsListStyles {
+    #[serde(default = "block_active")]
     pub block_active: Style,
+    #[serde(default = "block_inactive")]
     pub block_inactive: Style,
+    #[serde(default = "block_multi_select")]
     pub block_multi_select: Style,
+    #[serde(default = "highlight_active")]
     pub highlight_active: Style,
+    #[serde(default = "highlight_inactive")]
     pub highlight_inactive: Style,
+    #[serde(default = "title_active")]
     pub title_active: Style,
+    #[serde(default = "title_inactive")]
     pub title_inactive: Style,
     /// Styles when item is marked as selected in select mode
+    #[serde(default = "title_selected")]
     pub title_selected: Style,
+    #[serde(default = "date_priority")]
     pub date_priority: Style,
+    #[serde(default = "tags_default")]
     pub tags_default: Style,
 }
 
 impl Default for JournalsListStyles {
     fn default() -> Self {
-        let block_active = Style {
-            fg: Some(ACTIVE_CONTROL_COLOR),
-            modifiers: Modifier::BOLD,
-            ..Default::default()
-        };
-        let block_inactive = Style {
-            fg: Some(INACTIVE_CONTROL_COLOR),
-            ..Default::default()
-        };
-        let block_multi_select = Style {
-            fg: Some(SELECTED_FOREGROUND_COLOR),
-            modifiers: Modifier::BOLD | Modifier::ITALIC,
-            ..Default::default()
-        };
-
-        let highlight_active = Style {
-            fg: Some(Color::Black),
-            bg: Some(Color::LightGreen),
-            modifiers: Modifier::BOLD,
-            ..Default::default()
-        };
-
-        let highlight_inactive = Style {
-            fg: Some(Color::Black),
-            bg: Some(Color::LightBlue),
-            modifiers: Modifier::BOLD,
-            ..Default::default()
-        };
-
-        let title_active = Style {
-            fg: Some(ACTIVE_CONTROL_COLOR),
-            modifiers: Modifier::BOLD,
-            ..Default::default()
-        };
-        let title_inactive = Style {
-            fg: Some(INACTIVE_CONTROL_COLOR),
-            modifiers: Modifier::BOLD,
-            ..Default::default()
-        };
-        let title_selected = Style {
-            fg: Some(SELECTED_FOREGROUND_COLOR),
-            modifiers: Modifier::BOLD,
-            ..Default::default()
-        };
-
-        let date_priority = Style {
-            fg: Some(Color::LightBlue),
-            ..Default::default()
-        };
-
-        let tags_default = Style {
-            fg: Some(Color::LightCyan),
-            modifiers: Modifier::DIM,
-            ..Default::default()
-        };
-
         Self {
-            block_active,
-            block_inactive,
-            block_multi_select,
-            highlight_active,
-            highlight_inactive,
-            title_active,
-            title_inactive,
-            title_selected,
-            date_priority,
-            tags_default,
+            block_active: block_active(),
+            block_inactive: block_inactive(),
+            block_multi_select: block_multi_select(),
+            highlight_active: highlight_active(),
+            highlight_inactive: highlight_inactive(),
+            title_active: title_active(),
+            title_inactive: title_inactive(),
+            title_selected: title_selected(),
+            date_priority: date_priority(),
+            tags_default: tags_default(),
         }
+    }
+}
+
+#[inline]
+fn block_active() -> Style {
+    Style {
+        fg: Some(ACTIVE_CONTROL_COLOR),
+        modifiers: Modifier::BOLD,
+        ..Default::default()
+    }
+}
+
+#[inline]
+fn block_inactive() -> Style {
+    Style {
+        fg: Some(INACTIVE_CONTROL_COLOR),
+        ..Default::default()
+    }
+}
+
+#[inline]
+fn block_multi_select() -> Style {
+    Style {
+        fg: Some(SELECTED_FOREGROUND_COLOR),
+        modifiers: Modifier::BOLD | Modifier::ITALIC,
+        ..Default::default()
+    }
+}
+
+#[inline]
+fn highlight_active() -> Style {
+    Style {
+        fg: Some(Color::Black),
+        bg: Some(Color::LightGreen),
+        modifiers: Modifier::BOLD,
+        ..Default::default()
+    }
+}
+
+#[inline]
+fn highlight_inactive() -> Style {
+    Style {
+        fg: Some(Color::Black),
+        bg: Some(Color::LightBlue),
+        modifiers: Modifier::BOLD,
+        ..Default::default()
+    }
+}
+
+#[inline]
+fn title_active() -> Style {
+    Style {
+        fg: Some(ACTIVE_CONTROL_COLOR),
+        modifiers: Modifier::BOLD,
+        ..Default::default()
+    }
+}
+
+#[inline]
+fn title_inactive() -> Style {
+    Style {
+        fg: Some(INACTIVE_CONTROL_COLOR),
+        modifiers: Modifier::BOLD,
+        ..Default::default()
+    }
+}
+
+#[inline]
+fn title_selected() -> Style {
+    Style {
+        fg: Some(SELECTED_FOREGROUND_COLOR),
+        modifiers: Modifier::BOLD,
+        ..Default::default()
+    }
+}
+
+#[inline]
+fn date_priority() -> Style {
+    Style {
+        fg: Some(Color::LightBlue),
+        ..Default::default()
+    }
+}
+
+#[inline]
+fn tags_default() -> Style {
+    Style {
+        fg: Some(Color::LightCyan),
+        modifiers: Modifier::DIM,
+        ..Default::default()
     }
 }

--- a/src/app/ui/themes/mod.rs
+++ b/src/app/ui/themes/mod.rs
@@ -1,0 +1,1 @@
+mod style;

--- a/src/app/ui/themes/mod.rs
+++ b/src/app/ui/themes/mod.rs
@@ -69,13 +69,18 @@ impl Styles {
             )
         })?;
 
-        Self::deserialize(&file_content)
+        Self::deserialize(&file_content).with_context(|| {
+            format!(
+                "Error while desrializing toml text to styles. File path: {}",
+                file_path.display()
+            )
+        })
     }
 
     /// Deserialize [`Styles`] from the given text, filling the missing items from default
     /// implementation.
     fn deserialize(input: &str) -> anyhow::Result<Self> {
-        toml::from_str(input).context("Error while desrializing toml text to styles")
+        toml::from_str(input).map_err(|err| err.into())
     }
 }
 

--- a/src/app/ui/themes/mod.rs
+++ b/src/app/ui/themes/mod.rs
@@ -1,10 +1,12 @@
 mod editor_styles;
+mod journals_list_styles;
 mod style;
 
 use ratatui::style::Color;
 use serde::{Deserialize, Serialize};
 
 pub use editor_styles::EditorStyles;
+pub use journals_list_styles::JournalsListStyles;
 pub use style::Style;
 
 const ACTIVE_CONTROL_COLOR: Color = Color::Reset;
@@ -12,6 +14,7 @@ const INACTIVE_CONTROL_COLOR: Color = Color::Rgb(170, 170, 200);
 const EDITOR_MODE_COLOR: Color = Color::LightGreen;
 const INVALID_CONTROL_COLOR: Color = Color::LightRed;
 const VISUAL_MODE_COLOR: Color = Color::Blue;
+const SELECTED_FOREGROUND_COLOR: Color = Color::Yellow;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Styles {
@@ -24,15 +27,6 @@ pub struct Styles {
 pub struct GeneralStyles {}
 
 impl Default for GeneralStyles {
-    fn default() -> Self {
-        Self {}
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct JournalsListStyles {}
-
-impl Default for JournalsListStyles {
     fn default() -> Self {
         Self {}
     }

--- a/src/app/ui/themes/mod.rs
+++ b/src/app/ui/themes/mod.rs
@@ -1,4 +1,5 @@
 mod editor_styles;
+mod general_styles;
 mod journals_list_styles;
 mod style;
 
@@ -6,28 +7,21 @@ use ratatui::style::Color;
 use serde::{Deserialize, Serialize};
 
 pub use editor_styles::EditorStyles;
+pub use general_styles::GeneralStyles;
 pub use journals_list_styles::JournalsListStyles;
 pub use style::Style;
 
 const ACTIVE_CONTROL_COLOR: Color = Color::Reset;
 const INACTIVE_CONTROL_COLOR: Color = Color::Rgb(170, 170, 200);
 const EDITOR_MODE_COLOR: Color = Color::LightGreen;
-const INVALID_CONTROL_COLOR: Color = Color::LightRed;
 const VISUAL_MODE_COLOR: Color = Color::Blue;
 const SELECTED_FOREGROUND_COLOR: Color = Color::Yellow;
+const INVALID_CONTROL_COLOR: Color = Color::LightRed;
+const ACTIVE_INPUT_BORDER_COLOR: Color = Color::LightYellow;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Styles {
     pub general: GeneralStyles,
     pub journals_list: JournalsListStyles,
     pub editor: EditorStyles,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GeneralStyles {}
-
-impl Default for GeneralStyles {
-    fn default() -> Self {
-        Self {}
-    }
 }

--- a/src/app/ui/themes/mod.rs
+++ b/src/app/ui/themes/mod.rs
@@ -1,1 +1,39 @@
+mod editor_styles;
 mod style;
+
+use ratatui::style::Color;
+use serde::{Deserialize, Serialize};
+
+pub use editor_styles::EditorStyles;
+pub use style::Style;
+
+const ACTIVE_CONTROL_COLOR: Color = Color::Reset;
+const INACTIVE_CONTROL_COLOR: Color = Color::Rgb(170, 170, 200);
+const EDITOR_MODE_COLOR: Color = Color::LightGreen;
+const INVALID_CONTROL_COLOR: Color = Color::LightRed;
+const VISUAL_MODE_COLOR: Color = Color::Blue;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Styles {
+    pub general: GeneralStyles,
+    pub journals_list: JournalsListStyles,
+    pub editor: EditorStyles,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GeneralStyles {}
+
+impl Default for GeneralStyles {
+    fn default() -> Self {
+        Self {}
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JournalsListStyles {}
+
+impl Default for JournalsListStyles {
+    fn default() -> Self {
+        Self {}
+    }
+}

--- a/src/app/ui/themes/mod.rs
+++ b/src/app/ui/themes/mod.rs
@@ -2,8 +2,13 @@ mod editor_styles;
 mod general_styles;
 mod journals_list_styles;
 mod msgbox;
+mod serialization;
 mod style;
 
+use std::path::PathBuf;
+
+use anyhow::Context;
+use directories::BaseDirs;
 use ratatui::style::Color;
 use serde::{Deserialize, Serialize};
 
@@ -27,4 +32,24 @@ pub struct Styles {
     pub journals_list: JournalsListStyles,
     pub editor: EditorStyles,
     pub msgbox: MsgBoxColors,
+}
+
+impl Styles {
+    pub fn file_path() -> anyhow::Result<PathBuf> {
+        BaseDirs::new()
+            .map(|base_dirs| {
+                base_dirs
+                    .config_dir()
+                    .join("tui-journal")
+                    .join("themes.toml")
+            })
+            .context("Themes file path couldn't be retrieved")
+    }
+
+    /// Serialize default themes to `toml` format.
+    pub fn serialize_default() -> anyhow::Result<String> {
+        let def_style = Self::default();
+        toml::to_string_pretty(&def_style)
+            .context("Error while serializing default styles to toml format")
+    }
 }

--- a/src/app/ui/themes/mod.rs
+++ b/src/app/ui/themes/mod.rs
@@ -1,6 +1,7 @@
 mod editor_styles;
 mod general_styles;
 mod journals_list_styles;
+mod msgbox;
 mod style;
 
 use ratatui::style::Color;
@@ -9,6 +10,7 @@ use serde::{Deserialize, Serialize};
 pub use editor_styles::EditorStyles;
 pub use general_styles::GeneralStyles;
 pub use journals_list_styles::JournalsListStyles;
+pub use msgbox::MsgBoxColors;
 pub use style::Style;
 
 const ACTIVE_CONTROL_COLOR: Color = Color::Reset;
@@ -24,4 +26,5 @@ pub struct Styles {
     pub general: GeneralStyles,
     pub journals_list: JournalsListStyles,
     pub editor: EditorStyles,
+    pub msgbox: MsgBoxColors,
 }

--- a/src/app/ui/themes/mod.rs
+++ b/src/app/ui/themes/mod.rs
@@ -2,10 +2,9 @@ mod editor_styles;
 mod general_styles;
 mod journals_list_styles;
 mod msgbox;
-mod serialization;
 mod style;
 
-use std::path::PathBuf;
+use std::{fs, path::PathBuf};
 
 use anyhow::Context;
 use directories::BaseDirs;
@@ -28,9 +27,13 @@ const ACTIVE_INPUT_BORDER_COLOR: Color = Color::LightYellow;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Styles {
+    #[serde(default)]
     pub general: GeneralStyles,
+    #[serde(default)]
     pub journals_list: JournalsListStyles,
+    #[serde(default)]
     pub editor: EditorStyles,
+    #[serde(default)]
     pub msgbox: MsgBoxColors,
 }
 
@@ -51,5 +54,261 @@ impl Styles {
         let def_style = Self::default();
         toml::to_string_pretty(&def_style)
             .context("Error while serializing default styles to toml format")
+    }
+
+    pub fn load() -> anyhow::Result<Self> {
+        let file_path = Self::file_path()?;
+        if !file_path.exists() {
+            return Ok(Self::default());
+        }
+
+        let file_content = fs::read_to_string(&file_path).with_context(|| {
+            format!(
+                "Loading themes file content failed. Path: {}",
+                file_path.display()
+            )
+        })?;
+
+        Self::deserialize(&file_content)
+    }
+
+    /// Deserialize [`Styles`] from the given text, filling the missing items from default
+    /// implementation.
+    fn deserialize(input: &str) -> anyhow::Result<Self> {
+        toml::from_str(input).context("Error while desrializing toml text to styles")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::style::Modifier;
+
+    use super::*;
+
+    #[test]
+    fn full_general_only() {
+        let text = r##"
+[general.input_block_active]
+fg = "Yellow"
+modifiers = "DIM"
+
+[general.input_block_invalid]
+fg = "Red"
+modifiers = ""
+
+[general.input_corsur_active]
+fg = "Black"
+bg = "LightYellow"
+modifiers = ""
+
+[general.input_corsur_invalid]
+fg = "Black"
+bg = "LightRed"
+modifiers = ""
+
+[general.list_item_selected]
+fg = "LightYellow"
+modifiers = "BOLD"
+
+[general.list_highlight_active]
+fg = "Black"
+bg = "LightGreen"
+modifiers = ""
+
+[general.list_highlight_inactive]
+fg = "Black"
+bg = "LightBlue"
+modifiers = ""
+        "##;
+
+        let style = Styles::deserialize(text).unwrap();
+        assert_eq!(style.general.input_block_active.fg, Some(Color::Yellow));
+        assert_eq!(style.general.input_block_active.modifiers, Modifier::DIM);
+        assert_eq!(style.general.input_block_invalid.fg, Some(Color::Red));
+
+        assert_eq!(style.journals_list, JournalsListStyles::default());
+        assert_eq!(style.editor, EditorStyles::default());
+        assert_eq!(style.msgbox, MsgBoxColors::default());
+    }
+
+    #[test]
+    fn part_general_only() {
+        let text = r##"
+[general.input_block_active]
+fg = "Yellow"
+modifiers = "DIM"
+
+[general.input_block_invalid]
+fg = "Red"
+modifiers = ""
+        "##;
+
+        let style = Styles::deserialize(text).unwrap();
+        assert_eq!(style.general.input_block_active.fg, Some(Color::Yellow));
+        assert_eq!(style.general.input_block_active.modifiers, Modifier::DIM);
+        assert_eq!(style.general.input_block_invalid.fg, Some(Color::Red));
+
+        let def_general = GeneralStyles::default();
+        assert_eq!(
+            style.general.input_corsur_invalid,
+            def_general.input_corsur_invalid
+        );
+
+        assert_eq!(style.journals_list, JournalsListStyles::default());
+        assert_eq!(style.editor, EditorStyles::default());
+        assert_eq!(style.msgbox, MsgBoxColors::default());
+    }
+
+    #[test]
+    fn part_journals_list_only() {
+        let text = r##"
+[journals_list.block_active]
+fg = "Red"
+modifiers = "ITALIC"
+
+[journals_list.block_inactive]
+fg = "Reset"
+        "##;
+
+        let style = Styles::deserialize(text).unwrap();
+        assert_eq!(style.journals_list.block_active.fg, Some(Color::Red));
+        assert_eq!(style.journals_list.block_active.modifiers, Modifier::ITALIC);
+        assert_eq!(style.journals_list.block_inactive.fg, Some(Color::Reset));
+
+        let def_journals = JournalsListStyles::default();
+        assert_eq!(
+            style.journals_list.highlight_active,
+            def_journals.highlight_active
+        );
+        assert_eq!(
+            style.journals_list.highlight_inactive,
+            def_journals.highlight_inactive
+        );
+
+        assert_eq!(style.general, GeneralStyles::default());
+        assert_eq!(style.editor, EditorStyles::default());
+        assert_eq!(style.msgbox, MsgBoxColors::default());
+    }
+
+    #[test]
+    fn part_editor_only() {
+        let text = r##"
+[editor.block_insert]
+fg = "Blue"
+modifiers = ""
+
+[editor.block_visual]
+fg = "Red"
+        "##;
+
+        let style = Styles::deserialize(text).unwrap();
+        assert_eq!(style.editor.block_insert.fg, Some(Color::Blue));
+        assert_eq!(style.editor.block_insert.modifiers, Modifier::empty());
+        assert_eq!(style.editor.block_visual.fg, Some(Color::Red));
+
+        let def_editor = EditorStyles::default();
+        assert_eq!(style.editor.cursor_visual, def_editor.cursor_visual);
+        assert_eq!(style.editor.cursor_normal, def_editor.cursor_normal);
+
+        assert_eq!(style.journals_list, JournalsListStyles::default());
+        assert_eq!(style.general, GeneralStyles::default());
+        assert_eq!(style.msgbox, MsgBoxColors::default());
+    }
+
+    #[test]
+    fn part_msg_only() {
+        let text = r##"
+[msgbox]
+error = "Red"
+warning = "Blue"
+        "##;
+
+        let style = Styles::deserialize(text).unwrap();
+        assert_eq!(style.msgbox.error, Color::Red);
+        assert_eq!(style.msgbox.warning, Color::Blue);
+
+        let def_msg = MsgBoxColors::default();
+        assert_eq!(style.msgbox.info, def_msg.info);
+        assert_eq!(style.msgbox.question, def_msg.question);
+
+        assert_eq!(style.general, GeneralStyles::default());
+        assert_eq!(style.journals_list, JournalsListStyles::default());
+        assert_eq!(style.editor, EditorStyles::default());
+    }
+
+    #[test]
+    /// Tests input have a part of every style group
+    fn part_from_all() {
+        let text = r##"
+[general.input_block_active]
+fg = "Yellow"
+modifiers = "DIM"
+
+[general.input_block_invalid]
+fg = "Red"
+modifiers = ""
+
+[journals_list.block_active]
+fg = "Red"
+modifiers = "ITALIC"
+
+[journals_list.block_inactive]
+fg = "Reset"
+
+[editor.block_insert]
+fg = "Blue"
+modifiers = ""
+
+[editor.block_visual]
+fg = "Red"
+
+[msgbox]
+error = "Red"
+warning = "Blue"
+        "##;
+
+        // General
+        let style = Styles::deserialize(text).unwrap();
+        assert_eq!(style.general.input_block_active.fg, Some(Color::Yellow));
+        assert_eq!(style.general.input_block_active.modifiers, Modifier::DIM);
+        assert_eq!(style.general.input_block_invalid.fg, Some(Color::Red));
+
+        let def_general = GeneralStyles::default();
+        assert_eq!(
+            style.general.input_corsur_invalid,
+            def_general.input_corsur_invalid
+        );
+
+        // Journals
+        assert_eq!(style.journals_list.block_active.fg, Some(Color::Red));
+        assert_eq!(style.journals_list.block_active.modifiers, Modifier::ITALIC);
+        assert_eq!(style.journals_list.block_inactive.fg, Some(Color::Reset));
+
+        let def_journals = JournalsListStyles::default();
+        assert_eq!(
+            style.journals_list.highlight_active,
+            def_journals.highlight_active
+        );
+        assert_eq!(
+            style.journals_list.highlight_inactive,
+            def_journals.highlight_inactive
+        );
+
+        // Editor
+        assert_eq!(style.editor.block_insert.fg, Some(Color::Blue));
+        assert_eq!(style.editor.block_insert.modifiers, Modifier::empty());
+        assert_eq!(style.editor.block_visual.fg, Some(Color::Red));
+
+        let def_editor = EditorStyles::default();
+        assert_eq!(style.editor.cursor_visual, def_editor.cursor_visual);
+        assert_eq!(style.editor.cursor_normal, def_editor.cursor_normal);
+
+        // Colors
+        let def_msg = MsgBoxColors::default();
+        assert_eq!(style.msgbox.error, Color::Red);
+        assert_eq!(style.msgbox.warning, Color::Blue);
+
+        assert_eq!(style.msgbox.info, def_msg.info);
+        assert_eq!(style.msgbox.question, def_msg.question);
     }
 }

--- a/src/app/ui/themes/msgbox.rs
+++ b/src/app/ui/themes/msgbox.rs
@@ -1,0 +1,20 @@
+use super::*;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MsgBoxColors {
+    pub error: Color,
+    pub warning: Color,
+    pub info: Color,
+    pub question: Color,
+}
+
+impl Default for MsgBoxColors {
+    fn default() -> Self {
+        Self {
+            error: Color::LightRed,
+            warning: Color::Yellow,
+            info: Color::LightGreen,
+            question: Color::LightBlue,
+        }
+    }
+}

--- a/src/app/ui/themes/msgbox.rs
+++ b/src/app/ui/themes/msgbox.rs
@@ -1,20 +1,44 @@
 use super::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MsgBoxColors {
+    #[serde(default = "def_error")]
     pub error: Color,
+    #[serde(default = "def_warning")]
     pub warning: Color,
+    #[serde(default = "def_info")]
     pub info: Color,
+    #[serde(default = "def_question")]
     pub question: Color,
 }
 
 impl Default for MsgBoxColors {
     fn default() -> Self {
         Self {
-            error: Color::LightRed,
-            warning: Color::Yellow,
-            info: Color::LightGreen,
-            question: Color::LightBlue,
+            error: def_error(),
+            warning: def_warning(),
+            info: def_info(),
+            question: def_question(),
         }
     }
+}
+
+#[inline]
+fn def_error() -> Color {
+    Color::LightRed
+}
+
+#[inline]
+fn def_warning() -> Color {
+    Color::Yellow
+}
+
+#[inline]
+fn def_info() -> Color {
+    Color::LightGreen
+}
+
+#[inline]
+fn def_question() -> Color {
+    Color::LightBlue
 }

--- a/src/app/ui/themes/serialization.rs
+++ b/src/app/ui/themes/serialization.rs
@@ -1,7 +1,0 @@
-use super::*;
-
-/// Deserialize [`Styles`] from the given text, filling the missing items from default
-/// implementation.
-pub fn _deserialize(_input: &str) -> anyhow::Result<Styles> {
-    todo!()
-}

--- a/src/app/ui/themes/serialization.rs
+++ b/src/app/ui/themes/serialization.rs
@@ -1,0 +1,7 @@
+use super::*;
+
+/// Deserialize [`Styles`] from the given text, filling the missing items from default
+/// implementation.
+pub fn _deserialize(_input: &str) -> anyhow::Result<Styles> {
+    todo!()
+}

--- a/src/app/ui/themes/style.rs
+++ b/src/app/ui/themes/style.rs
@@ -19,7 +19,7 @@ impl From<Style> for RataStyle {
             fg: style.fg,
             underline_color: style.underline_color,
             add_modifier: Modifier::empty(),
-            sub_modifier: Modifier::empty(),
+            sub_modifier: Modifier::all(),
         };
 
         // Modifiers needed to be added via this method to be involved in both add and sub modifier

--- a/src/app/ui/themes/style.rs
+++ b/src/app/ui/themes/style.rs
@@ -1,7 +1,7 @@
 use ratatui::style::{Color, Modifier, Style as RataStyle};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Default)]
 /// Represents the style elements as they defined in [`ratatui`] lib but with more simple
 /// definitions for serialization so it's less confusing for users to define in custom themes.
 pub struct Style {

--- a/src/app/ui/themes/style.rs
+++ b/src/app/ui/themes/style.rs
@@ -1,0 +1,93 @@
+use ratatui::style::{Color, Modifier, Style as RataStyle};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
+/// Represents the style elements as they defined in [`ratatui`] lib but with more simple
+/// definitions for serialization so it's less confusing for users to define in custom themes.
+pub struct Style {
+    pub fg: Option<Color>,
+    pub bg: Option<Color>,
+    #[serde(default)]
+    pub modifiers: Modifier,
+    pub underline_color: Option<Color>,
+}
+
+impl From<Style> for RataStyle {
+    fn from(style: Style) -> Self {
+        let mut rata_style = RataStyle {
+            bg: style.bg,
+            fg: style.fg,
+            underline_color: style.underline_color,
+            add_modifier: Modifier::empty(),
+            sub_modifier: Modifier::empty(),
+        };
+
+        // Modifiers needed to be added via this method to be involved in both add and sub modifier
+        rata_style = rata_style.add_modifier(style.modifiers);
+        rata_style
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialize_style_json() {
+        let style_json = r##"{
+  "fg": "LightCyan",
+  "bg": "#4F11BA",
+  "modifiers": "DIM | UNDERLINED",
+  "underline_color": "#0A1432"
+}"##;
+
+        let style = Style {
+            fg: Some(Color::LightCyan),
+            bg: Some(Color::from_u32(0x004F11BA)),
+            underline_color: Some(Color::Rgb(10, 20, 50)),
+            modifiers: Modifier::UNDERLINED | Modifier::DIM,
+        };
+
+        let serialized = serde_json::from_str(style_json).unwrap();
+        assert_eq!(style, serialized);
+    }
+
+    #[test]
+    fn serialize_style_toml() {
+        let style_toml = r##"
+fg = "LightCyan"
+bg = "#4F11BA"
+modifiers = ""
+underline_color = "#0A1432"
+"##;
+
+        let style = Style {
+            fg: Some(Color::LightCyan),
+            bg: Some(Color::from_u32(0x004F11BA)),
+            underline_color: Some(Color::Rgb(10, 20, 50)),
+            modifiers: Modifier::empty(),
+        };
+
+        let serialized = toml::from_str(style_toml).unwrap();
+        assert_eq!(style, serialized);
+    }
+
+    #[test]
+    fn serialized_style_missing() {
+        let style_toml = r##"
+fg = "LightCyan"
+bg = "#4F11BA"
+"##;
+
+        let style = Style {
+            fg: Some(Color::LightCyan),
+            bg: Some(Color::from_u32(0x004F11BA)),
+            underline_color: None,
+            modifiers: Modifier::empty(),
+        };
+
+        let serialized = toml::from_str(style_toml).unwrap();
+
+        assert_eq!(style, serialized);
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -83,7 +83,7 @@ impl Cli {
         setup_logging(self.verbose, self.log_file)?;
 
         if let Some(cmd) = self.command.take() {
-            cmd.exec(settings).await
+            cmd.exec(settings)
         } else {
             Ok(CliResult::Continue)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use std::io;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use app::ui::Styles;
 use clap::Parser;
 use crossterm::{
     execute,
@@ -28,6 +29,7 @@ async fn main() -> Result<()> {
         cli::CliResult::PendingCommand(cmd) => pending_cmd = Some(cmd),
     }
 
+    let styles = Styles::load().context("Error while retrieving app styles")?;
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
@@ -36,7 +38,7 @@ async fn main() -> Result<()> {
 
     chain_panic_hook();
 
-    app::run(&mut terminal, settings, pending_cmd)
+    app::run(&mut terminal, settings, styles, pending_cmd)
         .await
         .inspect_err(|err| {
             log::error!("[PANIC] {}", err.to_string());


### PR DESCRIPTION
This PR closes #509 

It provides a complete framework to enable users to override the styles and colors of the app.

This PR includes:
* Move all styles into one central struct with default implementation.
* Users can override themes by defining them in `themes.toml` file in `tui-journal` directory within the config directory (More in themes documentations)
* CLI sub-commands to print default themes, print the path of themes files and write the default themes directly to the file.
* New `Themes.md` Document to explain theming in details.
* Small changes on current themes, enabling unified feel on UI across the app
* Cover serializing of theme with a lot of unit tests
* Update README with small fixes 