### PR TITLE
Json perf fixes

### DIFF
--- a/backend/src/json.rs
+++ b/backend/src/json.rs
@@ -105,12 +105,19 @@ impl DataProvider for JsonDataProvide {
     async fn assign_priority_to_entries(&self, priority: u32) -> anyhow::Result<()> {
         let mut entries = self.load_all_entries().await?;
 
+        let mut modified = false;
+
         entries
             .iter_mut()
             .filter(|entry| entry.priority.is_none())
-            .for_each(|entry| entry.priority = Some(priority));
+            .for_each(|entry| {
+                entry.priority = Some(priority);
+                modified = true;
+            });
 
-        self.write_entries_to_file(&entries).await?;
+        if modified {
+            self.write_entries_to_file(&entries).await?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
---
Found these when looking at implementing #599. The last one is a bit iffy. It looks like entries are sorted elsewhere, so having items swap around in the file should be ok…except when tracked in Git. I also considered using `Vec::retain` instead, but this will remove *all* entries with the given id, not just the first.