### PR TITLE
ci: remove macOS x86_64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,6 @@ jobs:
           - os: ubuntu-latest
             container: rust
             dependencies: "libssl-dev"
-          - os: macos-13
-            arch: x86_64
           - os: macos-latest
             arch: arm64
           - os: windows-latest
@@ -42,9 +40,6 @@ jobs:
       if: matrix.dependencies
       run: apt update && apt install -y ${{ matrix.dependencies }}
 
-    - name: Build Release Mac x86_64
-      if: matrix.os == 'macos-13' && matrix.arch == 'x86_64'
-      run: make release-mac-x86_64
     - name: Build Release Mac ARM64
       if: matrix.os == 'macos-latest' && matrix.arch == 'arm64'
       run: make release-mac-arm64


### PR DESCRIPTION
Github no longer supports Intel macOS, so remove it from CI.