### PR TITLE
Feat/markdown rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,6 +1130,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "markdown-tui"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a11daad23dc7abcd334a2ccc51918c8a8e2e9db7d445694277678467e1219bfc"
+dependencies = [
+ "ratatui",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2377,6 +2386,7 @@ dependencies = [
  "fuzzy-matcher",
  "git2",
  "log",
+ "markdown-tui",
  "path-absolutize",
  "ratatui",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ toml = "1"
 sqlx = {version = "0.8", features = ["runtime-tokio", "sqlite", "chrono"], optional = true}
 futures-util = { version = "0.3", default-features = false }
 aho-corasick = "1"
+markdown-tui = "0.1.3"
 
 scopeguard = "1"
 git2 = { version = "0.20", default-features = false }

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -248,6 +248,10 @@ pub fn get_entries_list_keymaps() -> Vec<Keymap> {
             Input::new(KeyCode::PageDown, KeyModifiers::NONE),
             UICommand::PageDownEntries,
         ),
+        Keymap::new(
+            Input::new(KeyCode::Char('p'), KeyModifiers::NONE),
+            UICommand::TogglePreviewMode,
+        ),
     ]
 }
 

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -366,6 +366,10 @@ pub fn get_multi_select_keymaps() -> Vec<Keymap> {
             Input::new(KeyCode::Char('>'), KeyModifiers::NONE),
             UICommand::MulSelExportEntries,
         ),
+        Keymap::new(
+            Input::new(KeyCode::Char('p'), KeyModifiers::NONE),
+            UICommand::TogglePreviewMode,
+        ),
         // Char '?' isn't recognized on windows
         #[cfg(not(target_os = "windows"))]
         Keymap::new(

--- a/src/app/ui/commands/editor_cmd.rs
+++ b/src/app/ui/commands/editor_cmd.rs
@@ -74,6 +74,11 @@ pub fn exec_toggle_editor_visual_mode(ui_components: &mut UIComponents) -> CmdRe
     Ok(HandleInputReturnType::Handled)
 }
 
+pub fn exec_toggle_preview_mode(ui_components: &mut UIComponents) -> CmdResult {
+    ui_components.editor.toggle_preview();
+    Ok(HandleInputReturnType::Handled)
+}
+
 pub fn exec_copy_os_clipboard(ui_components: &mut UIComponents) -> CmdResult {
     ui_components
         .editor

--- a/src/app/ui/commands/mod.rs
+++ b/src/app/ui/commands/mod.rs
@@ -57,6 +57,7 @@ pub enum UICommand {
     ShowFuzzyFind,
     ToggleEditorVisualMode,
     ToggleFullScreenMode,
+    TogglePreviewMode,
     CopyOsClipboard,
     CutOsClipboard,
     PasteOsClipboard,
@@ -188,6 +189,10 @@ impl UICommand {
                 "Toggle Full Screen Mode",
                 "Maximize the currently selected view",
             ),
+            UICommand::TogglePreviewMode => CommandInfo::new(
+                "Toggle Preview Mode",
+                "Toggle markdown preview mode for the current journal content",
+            ),
             UICommand::CopyOsClipboard => CommandInfo::new(
                 "Copy to OS clipboard",
                 "Copy selection to operation system clipboard while in editor visual mode",
@@ -262,6 +267,7 @@ impl UICommand {
             UICommand::ShowFuzzyFind => exec_show_fuzzy_find(ui_components, app),
             UICommand::ToggleEditorVisualMode => exec_toggle_editor_visual_mode(ui_components),
             UICommand::ToggleFullScreenMode => exec_toggle_full_screen_mode(app),
+            UICommand::TogglePreviewMode => exec_toggle_preview_mode(ui_components),
             UICommand::CopyOsClipboard => exec_copy_os_clipboard(ui_components),
             UICommand::CutOsClipboard => exec_cut_os_clipboard(ui_components),
             UICommand::PasteOsClipboard => exec_paste_os_clipboard(ui_components),
@@ -345,6 +351,7 @@ impl UICommand {
             }
             UICommand::ToggleEditorVisualMode => not_implemented(),
             UICommand::ToggleFullScreenMode => not_implemented(),
+            UICommand::TogglePreviewMode => not_implemented(),
             UICommand::CopyOsClipboard => not_implemented(),
             UICommand::CutOsClipboard => not_implemented(),
             UICommand::PasteOsClipboard => not_implemented(),

--- a/src/app/ui/editor/mod.rs
+++ b/src/app/ui/editor/mod.rs
@@ -567,10 +567,6 @@ impl<'a> Editor<'a> {
         self.show_preview = !self.show_preview;
         self.preview_scroll = 0;
     }
-
-    pub fn is_preview_mode(&self) -> bool {
-        self.show_preview
-    }
 }
 
 fn is_default_navigation(input: &Input) -> bool {

--- a/src/app/ui/editor/mod.rs
+++ b/src/app/ui/editor/mod.rs
@@ -153,14 +153,21 @@ impl<'a> Editor<'a> {
             match input.key_code {
                 KeyCode::Char('j') | KeyCode::Down => {
                     self.preview_scroll = self.preview_scroll.saturating_add(1);
+                    return Ok(HandleInputReturnType::Handled);
                 }
                 KeyCode::Char('k') | KeyCode::Up => {
                     self.preview_scroll = self.preview_scroll.saturating_sub(1);
+                    return Ok(HandleInputReturnType::Handled);
                 }
-                KeyCode::Char('p') => self.toggle_preview(),
-                _ => {}
+                KeyCode::Char('p') | KeyCode::Esc => {
+                    self.toggle_preview();
+                    return Ok(HandleInputReturnType::Handled);
+                }
+                _ => {
+                    self.show_preview = false;
+                    self.preview_scroll = 0;
+                }
             }
-            return Ok(HandleInputReturnType::Handled);
         }
         debug_assert!(!self.is_insert_mode());
 
@@ -342,6 +349,11 @@ impl<'a> Editor<'a> {
             _ => {}
         }
 
+        if matches!(mode, EditorMode::Insert | EditorMode::Visual) {
+            self.show_preview = false;
+            self.preview_scroll = 0;
+        }
+
         self.mode = mode;
     }
 
@@ -417,6 +429,32 @@ impl<'a> Editor<'a> {
             MarkdownWidget::new(&content).scroll(self.preview_scroll),
             inner,
         );
+
+        self.render_preview_scrollbar(frame, area, inner);
+    }
+
+    fn render_preview_scrollbar(&mut self, frame: &mut Frame, area: Rect, inner: Rect) {
+        let total_lines = self.text_area.lines().len();
+        if total_lines as u16 <= inner.height {
+            return;
+        }
+
+        let mut state = ScrollbarState::default()
+            .content_length(total_lines)
+            .position(self.preview_scroll as usize);
+
+        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .begin_symbol(Some("▲"))
+            .end_symbol(Some("▼"))
+            .track_symbol(Some(symbols::line::VERTICAL))
+            .thumb_symbol(symbols::block::FULL);
+
+        let scroll_area = area.inner(Margin {
+            horizontal: 0,
+            vertical: 1,
+        });
+
+        frame.render_stateful_widget(scrollbar, scroll_area, &mut state);
     }
 
     pub fn render_vertical_scrollbar(&mut self, frame: &mut Frame, area: Rect) {
@@ -566,6 +604,10 @@ impl<'a> Editor<'a> {
     pub fn toggle_preview(&mut self) {
         self.show_preview = !self.show_preview;
         self.preview_scroll = 0;
+    }
+
+    pub fn is_preview_mode(&self) -> bool {
+        self.show_preview
     }
 }
 

--- a/src/app/ui/editor/mod.rs
+++ b/src/app/ui/editor/mod.rs
@@ -13,6 +13,7 @@ use ratatui::{
 use crate::app::{App, keymap::Input, runner::HandleInputReturnType};
 
 use backend::DataProvider;
+use markdown_tui::widget::MarkdownWidget;
 use tui_textarea::{CursorMove, Scrolling, TextArea};
 
 use super::Styles;
@@ -31,6 +32,8 @@ pub struct Editor<'a> {
     is_active: bool,
     is_dirty: bool,
     has_unsaved: bool,
+    preview_scroll: u16,
+    show_preview: bool,
 }
 
 impl From<&Input> for KeyEvent {
@@ -54,6 +57,8 @@ impl<'a> Editor<'a> {
             is_active: false,
             is_dirty: false,
             has_unsaved: false,
+            show_preview: false,
+            preview_scroll: 0,
         }
     }
 
@@ -144,6 +149,19 @@ impl<'a> Editor<'a> {
         input: &Input,
         app: &App<D>,
     ) -> anyhow::Result<HandleInputReturnType> {
+        if self.show_preview {
+            match input.key_code {
+                KeyCode::Char('j') | KeyCode::Down => {
+                    self.preview_scroll = self.preview_scroll.saturating_add(1);
+                }
+                KeyCode::Char('k') | KeyCode::Up => {
+                    self.preview_scroll = self.preview_scroll.saturating_sub(1);
+                }
+                KeyCode::Char('p') => self.toggle_preview(),
+                _ => {}
+            }
+            return Ok(HandleInputReturnType::Handled);
+        }
         debug_assert!(!self.is_insert_mode());
 
         if app.get_current_entry().is_none() {
@@ -328,6 +346,10 @@ impl<'a> Editor<'a> {
     }
 
     pub fn render_widget(&mut self, frame: &mut Frame, area: Rect, styles: &Styles) {
+        if self.show_preview {
+            self.render_preview(frame, area, styles);
+            return;
+        }
         let mut title = "Content".to_owned();
         if self.is_active {
             let mode_caption = match self.mode {
@@ -380,6 +402,21 @@ impl<'a> Editor<'a> {
 
         self.render_vertical_scrollbar(frame, area);
         self.render_horizontal_scrollbar(frame, area);
+    }
+
+    fn render_preview(&mut self, frame: &mut Frame, area: Rect, styles: &Styles) {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .style(styles.editor.block_normal_active)
+            .title("Preview");
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        let content = self.get_content();
+        frame.render_widget(
+            MarkdownWidget::new(&content).scroll(self.preview_scroll),
+            inner,
+        );
     }
 
     pub fn render_vertical_scrollbar(&mut self, frame: &mut Frame, area: Rect) {
@@ -524,6 +561,15 @@ impl<'a> Editor<'a> {
         }
 
         Ok(HandleInputReturnType::Handled)
+    }
+
+    pub fn toggle_preview(&mut self) {
+        self.show_preview = !self.show_preview;
+        self.preview_scroll = 0;
+    }
+
+    pub fn is_preview_mode(&self) -> bool {
+        self.show_preview
     }
 }
 

--- a/src/app/ui/footer.rs
+++ b/src/app/ui/footer.rs
@@ -41,15 +41,31 @@ pub fn render_footer<D: DataProvider>(
 }
 
 fn get_footer_text<D: DataProvider>(ui_components: &UIComponents, app: &App<D>) -> String {
-    let (editor_mode, multi_select_mode) = (
+    let (editor_mode, multi_select_mode, preview_mode) = (
         ui_components.editor.is_insert_mode(),
         ui_components.entries_list.multi_select_mode,
+        ui_components.editor.is_preview_mode(),
     );
-    match (editor_mode, multi_select_mode) {
-        (true, false) => get_editor_mode_text(ui_components),
-        (false, true) => get_multi_select_text(ui_components),
+    match (editor_mode, multi_select_mode, preview_mode) {
+        (true, false, _) => get_editor_mode_text(ui_components),
+        (false, true, _) => get_multi_select_text(ui_components),
+        (false, false, true) => get_preview_mode_text(ui_components),
         _ => get_standard_text(ui_components, app),
     }
+}
+
+fn get_preview_mode_text(ui_components: &UIComponents) -> String {
+    let toggle_preview_keymap: Vec<_> = ui_components
+        .entries_list_keymaps
+        .iter()
+        .filter(|keymap| keymap.command == UICommand::TogglePreviewMode)
+        .collect();
+
+    format!(
+        "{}{}Scroll: 'j','k'",
+        get_keymap_text(toggle_preview_keymap),
+        SEPARATOR
+    )
 }
 
 fn get_editor_mode_text(ui_components: &UIComponents) -> String {
@@ -110,6 +126,14 @@ fn get_standard_text<D: DataProvider>(ui_components: &UIComponents, app: &App<D>
             .collect();
 
         footer_parts.push(get_keymap_text(sort_keymap));
+
+        let preview_keymap: Vec<_> = ui_components
+            .entries_list_keymaps
+            .iter()
+            .filter(|keymap| keymap.command == UICommand::TogglePreviewMode)
+            .collect();
+
+        footer_parts.push(get_keymap_text(preview_keymap));
     }
 
     if app.state.full_screen {

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use backend::DataProvider;
+use crossterm::event::KeyCode;
 pub use themes::Styles;
 
 use self::{
@@ -195,6 +196,11 @@ impl UIComponents<'_> {
     ) -> Result<HandleInputReturnType> {
         if self.has_popup() {
             return self.handle_popup_input(input, app).await;
+        }
+
+        if self.editor.is_preview_mode() && input.key_code == KeyCode::Esc {
+            self.editor.toggle_preview();
+            return Ok(HandleInputReturnType::Handled);
         }
 
         if self.editor.is_prioritized() {


### PR DESCRIPTION
Closes #604 

## Summary
Adds markdown preview mode to the journal content pane using the new 'markdown-tui' crate, which provides a custom lexer, parser, and ratatui widget implementation for rendering the markdown.

## Usage
Press 'p' while in the journals list to toggle preview mode on and off.
Use 'j'/'k' while in preview mode and cursor in the editor to scroll up and down in the markdown preview.

## What's working so far.
- Headings (all 6 levels)
- Bold, italic, bold-italic
- Inline code
- Code blocks with language tag
- Bullet and ordered lists
- Block quotes
- Horizontal rules
- Basic tables

## Current Limitations / planned follow-up
- Nested lists not yet supported
- Inline links not rendered
- Table edge cases still being polished
- Theming not yet integrated with TUI-journal's Styles system
- line_count(width) for page-up/down scroll support planned

## Crate
https://github.com/julian-myers/markdown-tui
https://crates.io/crates/markdown-tui

<img width="2560" height="1600" alt="non-preview-mode" src="https://github.com/user-attachments/assets/3933d513-3778-45f5-ab0e-5ba726d1f11d" />

<img width="2560" height="1600" alt="preview-mode" src="https://github.com/user-attachments/assets/2ac91f9b-f655-4e43-955c-2913d3c441dc" />

