### PR TITLE
editor: second Esc leaves editor and returns focus to entries list

### DIFF
--- a/src/app/ui/commands/editor_cmd.rs
+++ b/src/app/ui/commands/editor_cmd.rs
@@ -5,10 +5,15 @@ use backend::DataProvider;
 use super::{ClipboardOperation, CmdResult};
 
 pub fn exec_back_editor_to_normal_mode(ui_components: &mut UIComponents) -> CmdResult {
-    if ui_components.active_control == ControlType::EntryContentTxt
-        && ui_components.editor.is_prioritized()
-    {
-        ui_components.editor.set_editor_mode(EditorMode::Normal);
+    if ui_components.active_control == ControlType::EntryContentTxt {
+        match ui_components.editor.get_editor_mode() {
+            EditorMode::Insert | EditorMode::Visual => {
+                ui_components.editor.set_editor_mode(EditorMode::Normal);
+            }
+            EditorMode::Normal => {
+                ui_components.change_active_control(ControlType::EntriesList);
+            }
+        }
     }
 
     Ok(HandleInputReturnType::Handled)

--- a/src/app/ui/commands/mod.rs
+++ b/src/app/ui/commands/mod.rs
@@ -119,8 +119,8 @@ impl UICommand {
                 "Start editing current journal entry content in editor",
             ),
             UICommand::BackEditorNormalMode => CommandInfo::new(
-                "Back to Editor Normal Mode",
-                "Exit editor special modes (insert, visual) and go back to normal mode",
+                "Back to Editor Normal Mode / Leave Editor",
+                "Exit editor special modes (insert, visual) and go back to normal mode. If already in normal mode, leave the editor and return focus to the entries list",
             ),
             UICommand::SaveEntryContent => {
                 CommandInfo::new("Save", "Save changes on journal content")


### PR DESCRIPTION
BackEditorNormalMode was a no-op when the editor was already in Normal mode, leaving the user stuck in the editor widget with no single-key way back to the entries list. Extend the handler so that in Normal mode it changes the active control to EntriesList, while Insert and Visual continue to drop to Normal as before. Matches the vim muscle memory of pressing Esc until you're "out" of the editor.