### PR TITLE
entry: allow empty titles for date-only journals

### DIFF
--- a/src/app/ui/entries_list/mod.rs
+++ b/src/app/ui/entries_list/mod.rs
@@ -62,22 +62,23 @@ impl EntriesList {
                     title.insert_str(0, "* ");
                 }
 
-                // Text wrapping
-                let title_lines = textwrap::wrap(&title, area.width as usize - LIST_INNER_MARGIN);
-
-                // tilte lines
-                lines_count += title_lines.len();
-
                 let title_style = match (self.is_active, highlight_selected) {
                     (_, true) => jstyles.title_selected,
                     (true, _) => jstyles.title_active,
                     (false, _) => jstyles.title_inactive,
                 };
 
-                let mut spans: Vec<Line> = title_lines
-                    .iter()
-                    .map(|line| Line::from(Span::styled(line.to_string(), title_style)))
-                    .collect();
+                let mut spans: Vec<Line> = if title.trim().is_empty() {
+                    Vec::new()
+                } else {
+                    let title_lines =
+                        textwrap::wrap(&title, area.width as usize - LIST_INNER_MARGIN);
+                    lines_count += title_lines.len();
+                    title_lines
+                        .iter()
+                        .map(|line| Line::from(Span::styled(line.to_string(), title_style)))
+                        .collect()
+                };
 
                 // *** Date & Priority ***
                 let date_priority_lines = match (app.settings.datum_visibility, entry.priority) {

--- a/src/app/ui/entry_popup/mod.rs
+++ b/src/app/ui/entry_popup/mod.rs
@@ -339,11 +339,7 @@ impl EntryPopup<'_> {
     }
 
     fn validate_title(&mut self) {
-        if self.title_txt.lines()[0].is_empty() {
-            self.title_err_msg = "Title can't be empty".into();
-        } else {
-            self.title_err_msg.clear();
-        }
+        self.title_err_msg.clear();
     }
 
     fn validate_date(&mut self) {


### PR DESCRIPTION
Relaxes empty-title validation so users can create entries identified purely by date — useful for
  daily-journalling workflows where the date is already the primary identifier and a title is redundant.

  ## Why

  For date-driven journalling (e.g. a Notion-like "🔏 DAILY Journal" pattern), typing a placeholder title
  for every entry is friction. The entry model already stores a date, and the list view already shows it.

  ## Behaviour

  - **Before:** entry popup blocks confirmation with "Title can't be empty."
  - **After:** empty title is accepted. Journal list renders the date (and any tags) without the blank
  title line.

  ## Scope

  - `src/app/ui/entry_popup/mod.rs` — `validate_title` is now a no-op (function kept for future validation
  like max-length).
  - `src/app/ui/entries_list/mod.rs` — skip title rendering when title is empty or whitespace, so
  `textwrap::wrap("")` edge cases don't produce a blank line.

  ## Testing

  - `cargo check` / `cargo clippy --all-targets --all-features` — clean, no new warnings.
  - `cargo test --all-features` — all existing tests pass.
  - Manual smoke: created an entry with empty title, confirmed the popup accepts it, and verified the list
  shows date+tags with no title line artifact.

  ## Out of scope

  The related "auto-fill title from date when empty" behaviour (another reasonable UX choice) is
  deliberately not included — this PR just removes the block. Happy to iterate if you'd prefer a different
  default presentation.  Journalling workflows that key off the entry date (e.g. daily
  entries named purely by date) previously had to type a placeholder
  title to satisfy validation — "Title can't be empty" blocked the
  entry popup from confirming. Relax this so the title field is
  optional.

  - entry_popup::validate_title no longer rejects empty input; it just
    clears any previous error state. Function shape preserved so future
    validation (e.g. max length) can be reinstated without restructuring.
  - entries_list renders skip the title line entirely when the title is
    empty/whitespace, so the date (and any tags) remain visible cleanly
    without an awkward blank row.

  Verified with cargo check, cargo clippy --all-targets --all-features
  and the full test suite (no pre-existing tests for validate_title; no
  new regressions).
