### PR TITLE
settings: add tag_visibility to toggle tags in entries list

### DIFF
--- a/src/app/ui/entries_list/mod.rs
+++ b/src/app/ui/entries_list/mod.rs
@@ -16,7 +16,10 @@ use ratatui::{
 use backend::DataProvider;
 
 use crate::app::App;
-use crate::{app::keymap::Keymap, settings::DatumVisibility};
+use crate::{
+    app::keymap::Keymap,
+    settings::{DatumVisibility, TagVisibility},
+};
 
 use super::{Styles, UICommand};
 
@@ -128,7 +131,8 @@ impl EntriesList {
                 lines_count += date_priority_lines.len();
 
                 // *** Tags ***
-                if !entry.tags.is_empty() {
+                let show_tags = matches!(app.settings.tag_visibility, TagVisibility::Show);
+                if show_tags && !entry.tags.is_empty() {
                     const TAGS_SEPARATOR: &str = " | ";
                     let tags_default_style: Style = jstyles.tags_default.into();
 

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -60,6 +60,9 @@ pub struct Settings {
     #[serde(default)]
     /// Sets the visibility options for the datum of journals when rendered in entries list.
     pub datum_visibility: DatumVisibility,
+    #[serde(default)]
+    /// Sets the visibility options for the tags of journals when rendered in entries list.
+    pub tag_visibility: TagVisibility,
     /// Overwrite the path for the directory used to persist the app state.
     pub app_state_dir: Option<PathBuf>,
 }
@@ -80,6 +83,7 @@ impl Default for Settings {
             history_limit: default_history_limit(),
             colored_tags: default_colored_tags(),
             datum_visibility: Default::default(),
+            tag_visibility: Default::default(),
             app_state_dir: Default::default(),
         }
     }
@@ -97,6 +101,18 @@ pub enum DatumVisibility {
     Hide,
     /// Hide the datum providing an extra empty line if `priority` filed for the entry is empty.
     EmptyLine,
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, ValueEnum, Clone, Copy, Default)]
+#[serde(rename_all = "snake_case")]
+/// Represents the visibility options for tags of journals when rendered in the entries list.
+pub enum TagVisibility {
+    #[default]
+    /// Render the entry's tags beneath its title.
+    Show,
+    /// Hide tags from the entries list. Tags remain editable via the entry
+    /// details dialog.
+    Hide,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, ValueEnum, Clone, Copy, Default)]
@@ -172,6 +188,7 @@ impl Settings {
             history_limit: _,
             colored_tags: _,
             datum_visibility: _,
+            tag_visibility: _,
             app_state_dir: _,
         } = self;
 


### PR DESCRIPTION
Adds a `tag_visibility` setting so users can hide tags from the entries list view without affecting their
   storage or editing.

  ## Behaviour

  - **Default (`Show`)**: preserves existing rendering — tags appear beneath each entry's title in the
  list.
  - **`Hide`**: tags are omitted from the list. The tags remain on the entry and can be edited via the
  details dialog (`e`).

  ## Motivation

  For users whose entries have many tags (e.g. a large vocabulary of mood/category labels), the tags can
  dominate the list view and push titles out of view. Making visibility a per-install preference keeps the
  default unchanged for everyone else.

  ## Config

  ```toml
  tag_visibility = "hide"

  Testing

  - cargo check / cargo clippy --all-targets --all-features — clean.
  - cargo test --all-features — all existing tests pass, no new regressions.
  - Manual smoke: toggled between show and hide, confirmed tag rendering appears/disappears while the entry
   details dialog still shows tags for editing in both modes.  New setting `tag_visibility` (Show|Hide) mirrors the existing
  `datum_visibility` pattern. Defaults to Show to preserve current
  behaviour. When set to Hide, tags are omitted from the entries list
  rendering — they remain editable via the entry details dialog
  accessed with 'e'.

  Useful for users with long tag lists that clutter the journals list
  view.

<!--
Before opening this PR, read the Contribution and AI Policy in README.md.

Rules for contributions in this repository:
- Always start by opening an issue before starting implementation.
- Please try to write the issue yourself. A short issue with typos is better than a wall of AI-generated text.
- AI-generated code is allowed, but you must review it carefully before submitting.
- If this PR contains code that is clearly generated by AI and not reviewed by a human developer, you will be banned from contributing to this repository.
- If reviewing code generated by your agents is not worth your time, do not expect the maintainer to waste time reviewing it for you.
-->

## Contribution and AI Policy

- [ ] I have read and accept the Contribution and AI Policy in `README.md`, and I have reviewed this PR myself.
