### PR TITLE
feat(settings,ui): add auto_title config for pre-populating new-entry title

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,13 @@ backend_type = "Sqlite"   # Available options: Json, Sqlite. Default value: Sqli
 
 default_journal_priority = 3  # Sets the suggested priority while creating a new journal
 
+auto_title = { kind = "date" } # Pre-populates the title field when creating a new entry. Two forms are accepted:
+#   - Literal string: `auto_title = "Daily Note"` inserts the text as-is.
+#   - Computed value: `auto_title = { kind = "date" }` inserts today's date as DD-MM-YYYY.
+# Omit the key entirely (default) to leave the title field empty.
+# Note: the string form is always literal. `auto_title = "date"` inserts the literal word "date",
+# not today's date — use the struct form `{ kind = "date" }` for computed values.
+
 scroll_per_page = 5  # Sets how many journals will be scrolled when using page up/down commands
 
 sync_os_clipboard = false  # Syncs editor clipboard actions with operating system clipboard
@@ -312,4 +319,3 @@ In the age of powerful AI agents, we need to specify clear rules for contributio
 ## License
 
 [MIT](https://choosealicense.com/licenses/mit/)
-

--- a/README.md
+++ b/README.md
@@ -243,6 +243,13 @@ backend_type = "Sqlite"   # Available options: Json, Sqlite, Vjournal. Default v
 
 default_journal_priority = 3  # Sets the suggested priority while creating a new journal
 
+auto_title = { kind = "date" } # Pre-populates the title field when creating a new entry. Two forms are accepted:
+#   - Literal string: `auto_title = "Daily Note"` inserts the text as-is.
+#   - Computed value: `auto_title = { kind = "date" }` inserts today's date as DD-MM-YYYY.
+# Omit the key entirely (default) to leave the title field empty.
+# Note: the string form is always literal. `auto_title = "date"` inserts the literal word "date",
+# not today's date — use the struct form `{ kind = "date" }` for computed values.
+
 scroll_per_page = 5  # Sets how many journals will be scrolled when using page up/down commands
 
 sync_os_clipboard = false  # Syncs editor clipboard actions with operating system clipboard

--- a/src/app/ui/entry_popup/mod.rs
+++ b/src/app/ui/entry_popup/mod.rs
@@ -57,7 +57,11 @@ pub enum EntryPopupInputReturn {
 
 impl EntryPopup<'_> {
     pub fn new_entry(settings: &Settings) -> Self {
-        let title_txt = TextArea::default();
+        let title_txt = if let Some(auto_title) = &settings.auto_title {
+            TextArea::new(vec![auto_title.resolve()])
+        } else {
+            TextArea::default()
+        };
 
         let date = Local::now();
 

--- a/src/app/ui/entry_popup/mod.rs
+++ b/src/app/ui/entry_popup/mod.rs
@@ -57,11 +57,12 @@ pub enum EntryPopupInputReturn {
 
 impl EntryPopup<'_> {
     pub fn new_entry(settings: &Settings) -> Self {
-        let title_txt = if let Some(auto_title) = &settings.auto_title {
+        let mut title_txt = if let Some(auto_title) = &settings.auto_title {
             TextArea::new(vec![auto_title.resolve()])
         } else {
             TextArea::default()
         };
+        title_txt.move_cursor(CursorMove::End);
 
         let date = Local::now();
 

--- a/src/settings/auto_title.rs
+++ b/src/settings/auto_title.rs
@@ -1,0 +1,50 @@
+use chrono::{Datelike, Local};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum AutoTitle {
+    Literal(String),
+    Computed { kind: ComputedKind },
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ComputedKind {
+    Date,
+}
+
+impl AutoTitle {
+    pub fn resolve(&self) -> String {
+        match self {
+            Self::Literal(text) => text.clone(),
+            Self::Computed { kind } => match kind {
+                ComputedKind::Date => {
+                    let now = Local::now();
+                    format!("{:02}-{:02}-{}", now.day(), now.month(), now.year())
+                }
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_literal_returns_text() {
+        let value = AutoTitle::Literal(String::from("Hello world"));
+        assert_eq!(value.resolve(), "Hello world");
+    }
+
+    #[test]
+    fn resolve_date_matches_today() {
+        let value = AutoTitle::Computed {
+            kind: ComputedKind::Date,
+        };
+        let now = Local::now();
+        let expected = format!("{:02}-{:02}-{}", now.day(), now.month(), now.year());
+        assert_eq!(value.resolve(), expected);
+    }
+}

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -20,13 +20,14 @@ use crate::app::state::AppState;
 use self::json_backend::{JsonBackend, get_default_json_path};
 #[cfg(feature = "sqlite")]
 use self::sqlite_backend::{SqliteBackend, get_default_sqlite_path};
-use self::{export::ExportSettings, external_editor::ExternalEditor};
+use self::{auto_title::AutoTitle, export::ExportSettings, external_editor::ExternalEditor};
 
 #[cfg(feature = "json")]
 pub mod json_backend;
 #[cfg(feature = "sqlite")]
 pub mod sqlite_backend;
 
+mod auto_title;
 mod export;
 mod external_editor;
 
@@ -48,6 +49,8 @@ pub struct Settings {
     pub sqlite_backend: SqliteBackend,
     #[serde(default)]
     pub default_journal_priority: Option<u32>,
+    #[serde(default)]
+    pub auto_title: Option<AutoTitle>,
     #[serde(default)]
     pub scroll_per_page: Option<usize>,
     #[serde(default)]
@@ -75,6 +78,7 @@ impl Default for Settings {
             #[cfg(feature = "sqlite")]
             sqlite_backend: Default::default(),
             default_journal_priority: Default::default(),
+            auto_title: Default::default(),
             scroll_per_page: Default::default(),
             sync_os_clipboard: Default::default(),
             history_limit: default_history_limit(),
@@ -167,6 +171,7 @@ impl Settings {
             export: _,
             external_editor: _,
             default_journal_priority: _,
+            auto_title: _,
             scroll_per_page: _,
             sync_os_clipboard: _,
             history_limit: _,
@@ -276,6 +281,7 @@ where
 mod tests {
     use std::{fs, path::PathBuf};
 
+    use super::auto_title::ComputedKind;
     use super::*;
     use tempfile::{Builder, TempDir};
 
@@ -364,6 +370,41 @@ temp_file_extension = "md"
         );
         assert!(settings.external_editor.auto_save);
         assert_eq!(settings.external_editor.temp_file_extension, "md");
+    }
+
+    #[test]
+    fn auto_title_accepts_literal_string() {
+        let settings: Settings = toml::from_str(r#"auto_title = "Daily Note""#).unwrap();
+
+        assert_eq!(
+            settings.auto_title,
+            Some(AutoTitle::Literal(String::from("Daily Note")))
+        );
+    }
+
+    #[test]
+    fn auto_title_accepts_computed_struct() {
+        let settings: Settings = toml::from_str(
+            r#"
+[auto_title]
+kind = "date"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            settings.auto_title,
+            Some(AutoTitle::Computed {
+                kind: ComputedKind::Date,
+            })
+        );
+    }
+
+    #[test]
+    fn auto_title_defaults_to_none() {
+        let settings: Settings = toml::from_str("").unwrap();
+
+        assert_eq!(settings.auto_title, None);
     }
 
     #[test]

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -22,7 +22,7 @@ use self::json_backend::{JsonBackend, get_default_json_path};
 use self::sqlite_backend::{SqliteBackend, get_default_sqlite_path};
 #[cfg(feature = "vjournal")]
 use self::vjournal_backend::{VjournalBackend, get_default_vjournal_path};
-use self::{export::ExportSettings, external_editor::ExternalEditor};
+use self::{auto_title::AutoTitle, export::ExportSettings, external_editor::ExternalEditor};
 
 #[cfg(feature = "json")]
 pub mod json_backend;
@@ -31,6 +31,7 @@ pub mod sqlite_backend;
 #[cfg(feature = "vjournal")]
 pub mod vjournal_backend;
 
+mod auto_title;
 mod export;
 mod external_editor;
 
@@ -55,6 +56,8 @@ pub struct Settings {
     pub vjournal_backend: VjournalBackend,
     #[serde(default)]
     pub default_journal_priority: Option<u32>,
+    #[serde(default)]
+    pub auto_title: Option<AutoTitle>,
     #[serde(default)]
     pub scroll_per_page: Option<usize>,
     #[serde(default)]
@@ -84,6 +87,7 @@ impl Default for Settings {
             #[cfg(feature = "vjournal")]
             vjournal_backend: Default::default(),
             default_journal_priority: Default::default(),
+            auto_title: Default::default(),
             scroll_per_page: Default::default(),
             sync_os_clipboard: Default::default(),
             history_limit: default_history_limit(),
@@ -187,6 +191,7 @@ impl Settings {
             export: _,
             external_editor: _,
             default_journal_priority: _,
+            auto_title: _,
             scroll_per_page: _,
             sync_os_clipboard: _,
             history_limit: _,
@@ -301,6 +306,7 @@ where
 mod tests {
     use std::{fs, path::PathBuf};
 
+    use super::auto_title::ComputedKind;
     use super::*;
     use tempfile::{Builder, TempDir};
 
@@ -389,6 +395,41 @@ temp_file_extension = "md"
         );
         assert!(settings.external_editor.auto_save);
         assert_eq!(settings.external_editor.temp_file_extension, "md");
+    }
+
+    #[test]
+    fn auto_title_accepts_literal_string() {
+        let settings: Settings = toml::from_str(r#"auto_title = "Daily Note""#).unwrap();
+
+        assert_eq!(
+            settings.auto_title,
+            Some(AutoTitle::Literal(String::from("Daily Note")))
+        );
+    }
+
+    #[test]
+    fn auto_title_accepts_computed_struct() {
+        let settings: Settings = toml::from_str(
+            r#"
+[auto_title]
+kind = "date"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            settings.auto_title,
+            Some(AutoTitle::Computed {
+                kind: ComputedKind::Date,
+            })
+        );
+    }
+
+    #[test]
+    fn auto_title_defaults_to_none() {
+        let settings: Settings = toml::from_str("").unwrap();
+
+        assert_eq!(settings.auto_title, None);
     }
 
     #[test]


### PR DESCRIPTION
Closes #620 

## Summary

Adds a `auto_title` config option that pre-populates the title field when creating a new entry. Two forms are supported:

- Literal: `auto_title = "Daily Note"` → title pre-fills with "Daily Note".
- Computed: `auto_title = { kind = "date" }` → title pre-fills with today's
    date in DD-MM-YYYY format.

When unset (the default), behaviour is unchanged - title starts empty.

## Design choices worth noting

Used an untagged enum rather than string_or_struct (the external_editor pattern) - auto_title is "pick one of N modes," not "one thing with sub-settings." Compile-time mutual exclusivity, and new kinds become one-line additions. Happy to switch if you'd rather match the existing pattern.

String form is always literal: auto_title = "date" inserts the word "date", not today's date. Computed needs { kind = "date" }. Otherwise "date" would be unusable as an actual title.

Date format here matches the popup's DD-MM-YYYY input. The entries list view still uses unpadded {},{},{} which is a pre-existing mismatch, not this PR's job. #591 covers it.

## Explicitly out of scope

  - Configurable date formats - see #591
  - Better serde errors on malformed config (untagged enum gives generic messages)
  - Other computed kinds (weekday, iso_date) - trivial to add via ComputedKind

## Tests

 - `auto_title::tests::resolve_literal_returns_text` — resolution layer (literal branch).
 - `auto_title::tests::resolve_date_matches_today` — resolution layer (date branch, format validation).
 - `settings::tests::auto_title_accepts_literal_string` — TOML deser (string form → Literal).
 - `settings::tests::auto_title_accepts_computed_struct` — TOML deser (struct form → Computed).
 - `settings::tests::auto_title_defaults_to_none` — non-breaking for existing users with no `auto_title` key in config.

Manually verified all three cases end-to-end in the running app (computed date, literal string, no-config regression).

## Contribution and AI Policy

- [x] I have read and accept the Contribution and AI Policy in `README.md`, and I have reviewed this PR myself.
