### PR TITLE
fix(history): remap entry ids after restoring a deleted entry

### DIFF
--- a/src/app/history.rs
+++ b/src/app/history.rs
@@ -83,6 +83,25 @@ impl HistoryManager {
     pub fn pop_redo(&mut self) -> Option<Change> {
         self.redo_stack.pop_front()
     }
+
+    /// Rewrites every reference to `old` in both stacks to `new`. Used when an
+    /// undo replays a removal and the backend assigns a different id to the
+    /// restored entry, so subsequent stack entries don't reference an id that
+    /// no longer exists.
+    pub fn remap_entry_id(&mut self, old: u32, new: u32) {
+        if old == new {
+            return;
+        }
+        for change in self.undo_stack.iter_mut().chain(self.redo_stack.iter_mut()) {
+            match change {
+                Change::AddEntry { id } if *id == old => *id = new,
+                Change::RemoveEntry(entry) if entry.id == old => entry.id = new,
+                Change::EntryAttribute(attr) if attr.id == old => attr.id = new,
+                Change::EntryContent { id, .. } if *id == old => *id = new,
+                _ => {}
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -567,7 +567,8 @@ where
             }
             Change::RemoveEntry(entry) => {
                 log::trace!("History Apply: Remove Entry: {entry:?}");
-                let id = self
+                let old_id = entry.id;
+                let new_id = self
                     .add_entry_intern(
                         entry.title,
                         entry.date,
@@ -578,7 +579,9 @@ where
                     )
                     .await?;
 
-                Ok(Some(id))
+                self.history.remap_entry_id(old_id, new_id);
+
+                Ok(Some(new_id))
             }
             Change::EntryAttribute(attr) => {
                 log::trace!("History Apply: Change Attributes: {attr:?}");

--- a/src/app/test/undo_redo.rs
+++ b/src/app/test/undo_redo.rs
@@ -152,3 +152,39 @@ async fn many() {
         assert_eq!(app.entries.len(), current_count);
     }
 }
+
+#[tokio::test]
+/// Undo of an EntryContent change must succeed even after a previous undo step
+/// restored a deleted entry under a new id (because the backend assigned the
+/// next free id rather than the original).
+async fn undo_after_restore_with_new_id() {
+    let mut app = create_default_app();
+    app.load_entries().await.unwrap();
+
+    let a_id = app
+        .add_entry("A".into(), DateTime::default(), vec![], None)
+        .await
+        .unwrap();
+    let _b_id = app
+        .add_entry("B".into(), DateTime::default(), vec![], None)
+        .await
+        .unwrap();
+
+    app.current_entry_id = Some(a_id);
+    app.update_current_entry_content("edited content".into())
+        .await
+        .unwrap();
+
+    app.delete_entry(a_id).await.unwrap();
+
+    let restored_id = app.undo().await.unwrap().unwrap();
+    assert_ne!(
+        restored_id, a_id,
+        "precondition: restored entry must have a new id for this regression test to be meaningful"
+    );
+
+    app.undo().await.unwrap();
+
+    let restored = app.get_entry(restored_id).expect("restored entry exists");
+    assert_eq!(restored.content, "");
+}


### PR DESCRIPTION
Closes #623

Undo of a delete calls `add_entry_intern`, which gets a fresh id from the backend. If the restored entry gets a different id than the original (e.g. when deleting a non-max-id entry, since SQLite's `INTEGER PRIMARY KEY` without AUTOINCREMENT only reuses the highest freed rowid), subsequent history entries referencing the original id panic on the next undo or redo.

Added `HistoryManager::remap_entry_id` and call it from `apply_history_change` after `add_entry_intern` returns. Regression test in `src/app/test/undo_redo.rs` reproduces the panic without the fix and passes with it.

Open to refactoring if you'd prefer the remap logic elsewhere - happy to follow your steer.

- [x] I have read and accept the Contribution and AI Policy in `README.md`, and I have reviewed this PR myself.