### PR TITLE
Fix undo restore to keep original entry id

### DIFF
--- a/backend/src/json.rs
+++ b/backend/src/json.rs
@@ -57,6 +57,27 @@ impl DataProvider for JsonDataProvide {
         Ok(entries.into_iter().next_back().unwrap())
     }
 
+    async fn restore_entry(&self, entry: Entry) -> Result<Entry, ModifyEntryError> {
+        if entry.title.is_empty() {
+            return Err(ModifyEntryError::ValidationError(
+                "Entry title can't be empty".into(),
+            ));
+        }
+
+        let mut entries = self.load_all_entries().await?;
+        if entries.iter().any(|existing| existing.id == entry.id) {
+            return Err(ModifyEntryError::ValidationError(format!(
+                "Entry id {} already exists",
+                entry.id
+            )));
+        }
+
+        entries.push(entry.clone());
+        self.write_entries_to_file(&entries).await?;
+
+        Ok(entry)
+    }
+
     async fn remove_entry(&self, entry_id: u32) -> anyhow::Result<()> {
         let mut entries = self.load_all_entries().await?;
 

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -27,6 +27,8 @@ pub enum ModifyEntryError {
 pub trait DataProvider {
     async fn load_all_entries(&self) -> anyhow::Result<Vec<Entry>>;
     async fn add_entry(&self, entry: EntryDraft) -> Result<Entry, ModifyEntryError>;
+    /// Restores an entry with its existing id. Implementations must not overwrite another entry.
+    async fn restore_entry(&self, entry: Entry) -> Result<Entry, ModifyEntryError>;
     async fn remove_entry(&self, entry_id: u32) -> anyhow::Result<()>;
     async fn update_entry(&self, entry: Entry) -> Result<Entry, ModifyEntryError>;
     async fn get_export_object(&self, entries_ids: &[u32]) -> anyhow::Result<EntriesDTO>;
@@ -198,6 +200,10 @@ mod tests {
             }
 
             Ok(Entry::from_draft(call_idx as u32, entry))
+        }
+
+        async fn restore_entry(&self, _entry: Entry) -> Result<Entry, ModifyEntryError> {
+            unreachable!("not used in these tests");
         }
 
         async fn remove_entry(&self, _entry_id: u32) -> anyhow::Result<()> {

--- a/backend/src/sqlite/mod.rs
+++ b/backend/src/sqlite/mod.rs
@@ -70,6 +70,22 @@ impl SqliteDataProvide {
 
         Ok(Self { pool })
     }
+
+    async fn insert_tags(&self, entry_id: u32, tags: &[String]) -> Result<(), ModifyEntryError> {
+        for tag in tags {
+            sqlx::query(
+                r"INSERT INTO tags (entry_id, tag)
+                VALUES($1, $2)",
+            )
+            .bind(entry_id)
+            .bind(tag)
+            .execute(&self.pool)
+            .await
+            .with_context(|| format!("Failed to add tag '{tag}' to entry {entry_id}"))?;
+        }
+
+        Ok(())
+    }
 }
 
 impl DataProvider for SqliteDataProvide {
@@ -106,19 +122,28 @@ impl DataProvider for SqliteDataProvide {
 
         let id = row.get::<u32, _>(0);
 
-        for tag in entry.tags.iter() {
-            sqlx::query(
-                r"INSERT INTO tags (entry_id, tag)
-                VALUES($1, $2)",
-            )
-            .bind(id)
-            .bind(tag)
-            .execute(&self.pool)
-            .await
-            .with_context(|| format!("Failed to add tag '{tag}' to entry {id}"))?;
-        }
+        self.insert_tags(id, &entry.tags).await?;
 
         Ok(Entry::from_draft(id, entry))
+    }
+
+    async fn restore_entry(&self, entry: Entry) -> Result<Entry, ModifyEntryError> {
+        sqlx::query(
+            r"INSERT INTO entries (id, title, date, content, priority)
+            VALUES($1, $2, $3, $4, $5)",
+        )
+        .bind(entry.id)
+        .bind(&entry.title)
+        .bind(entry.date)
+        .bind(&entry.content)
+        .bind(entry.priority)
+        .execute(&self.pool)
+        .await
+        .with_context(|| format!("Failed to restore entry {}", entry.id))?;
+
+        self.insert_tags(entry.id, &entry.tags).await?;
+
+        Ok(entry)
     }
 
     async fn remove_entry(&self, entry_id: u32) -> anyhow::Result<()> {

--- a/backend/tests/json/mod.rs
+++ b/backend/tests/json/mod.rs
@@ -88,6 +88,45 @@ async fn remove_entry() {
 }
 
 #[tokio::test]
+async fn restore_entry_preserves_id() {
+    let temp_file = Builder::new()
+        .prefix("json_restore_entry")
+        .tempfile()
+        .unwrap();
+    let provider = create_provide_with_two_entries(&temp_file).await;
+
+    let restored_entry = provider
+        .load_all_entries()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|entry| entry.id == 0)
+        .unwrap();
+
+    provider.remove_entry(restored_entry.id).await.unwrap();
+    let added = provider
+        .add_entry(EntryDraft::new(
+            Utc.with_ymd_and_hms(2024, 5, 6, 7, 8, 9).unwrap(),
+            String::from("Added"),
+            vec![],
+            None,
+        ))
+        .await
+        .unwrap();
+    assert_ne!(added.id, restored_entry.id);
+
+    let restored = provider
+        .restore_entry(restored_entry.clone())
+        .await
+        .unwrap();
+
+    assert_eq!(restored, restored_entry);
+
+    let entries = provider.load_all_entries().await.unwrap();
+    assert!(entries.iter().any(|entry| entry == &restored_entry));
+}
+
+#[tokio::test]
 async fn update_entry() {
     let temp_file = Builder::new()
         .prefix("json_update_entry")

--- a/backend/tests/sqlite/mod.rs
+++ b/backend/tests/sqlite/mod.rs
@@ -84,6 +84,40 @@ async fn remove_entry() {
 }
 
 #[tokio::test]
+async fn restore_entry_preserves_id() {
+    let provider = create_provider_with_two_entries().await;
+    let restored_entry = provider
+        .load_all_entries()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|entry| entry.id == 1)
+        .unwrap();
+
+    provider.remove_entry(restored_entry.id).await.unwrap();
+    let added = provider
+        .add_entry(EntryDraft::new(
+            Utc.with_ymd_and_hms(2024, 5, 6, 7, 8, 9).unwrap(),
+            String::from("Added"),
+            vec![],
+            None,
+        ))
+        .await
+        .unwrap();
+    assert_ne!(added.id, restored_entry.id);
+
+    let restored = provider
+        .restore_entry(restored_entry.clone())
+        .await
+        .unwrap();
+
+    assert_eq!(restored, restored_entry);
+
+    let entries = provider.load_all_entries().await.unwrap();
+    assert!(entries.iter().any(|entry| entry == &restored_entry));
+}
+
+#[tokio::test]
 async fn update_entry() {
     let provider = create_provider_with_two_entries().await;
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -179,6 +179,27 @@ where
         Ok(entry_id)
     }
 
+    async fn restore_entry_intern(
+        &mut self,
+        entry: Entry,
+        history_target: HistoryStack,
+    ) -> anyhow::Result<u32> {
+        log::trace!("Restoring entry");
+
+        let entry = self.data_provide.restore_entry(entry).await?;
+        let entry_id = entry.id;
+
+        self.history.register_add(history_target, &entry);
+
+        self.entries.push(entry);
+
+        self.sort_entries();
+        self.update_filtered_out_entries();
+        self.update_colored_tags();
+
+        Ok(entry_id)
+    }
+
     /// Updates the attributes of the currently selected [`Entry`]
     pub async fn update_current_entry_attributes(
         &mut self,
@@ -567,16 +588,7 @@ where
             }
             Change::RemoveEntry(entry) => {
                 log::trace!("History Apply: Remove Entry: {entry:?}");
-                let id = self
-                    .add_entry_intern(
-                        entry.title,
-                        entry.date,
-                        entry.tags,
-                        entry.priority,
-                        Some(entry.content),
-                        history_target,
-                    )
-                    .await?;
+                let id = self.restore_entry_intern(*entry, history_target).await?;
 
                 Ok(Some(id))
             }

--- a/src/app/test/mock.rs
+++ b/src/app/test/mock.rs
@@ -41,9 +41,25 @@ impl DataProvider for MockDataProvider {
     async fn add_entry(&self, entry: EntryDraft) -> Result<Entry, ModifyEntryError> {
         self.early_return()?;
         let mut entries = self.entries.write().unwrap();
-        let new_id = entries.last().map_or(0, |entry| entry.id + 1);
+        let new_id = entries.iter().map(|entry| entry.id + 1).max().unwrap_or(0);
 
         let entry = Entry::from_draft(new_id, entry);
+
+        entries.push(entry.clone());
+
+        Ok(entry)
+    }
+
+    async fn restore_entry(&self, entry: Entry) -> Result<Entry, ModifyEntryError> {
+        self.early_return()?;
+
+        let mut entries = self.entries.write().unwrap();
+        if entries.iter().any(|existing| existing.id == entry.id) {
+            return Err(ModifyEntryError::ValidationError(format!(
+                "Entry id {} already exists",
+                entry.id
+            )));
+        }
 
         entries.push(entry.clone());
 

--- a/src/app/test/undo_redo.rs
+++ b/src/app/test/undo_redo.rs
@@ -125,6 +125,39 @@ async fn update_content() {
 }
 
 #[tokio::test]
+async fn undo_redo_after_restoring_deleted_entry_keeps_history_id() {
+    let mut app = create_default_app();
+    app.load_entries().await.unwrap();
+
+    let a_id = app
+        .add_entry("A".into(), DateTime::default(), vec![], None)
+        .await
+        .unwrap();
+    let _b_id = app
+        .add_entry("B".into(), DateTime::default(), vec![], None)
+        .await
+        .unwrap();
+
+    app.current_entry_id = Some(a_id);
+    app.update_current_entry_content("edited content".into())
+        .await
+        .unwrap();
+    app.delete_entry(a_id).await.unwrap();
+
+    let restored_id = app.undo().await.unwrap().unwrap();
+    assert_eq!(restored_id, a_id);
+
+    app.undo().await.unwrap();
+    assert_eq!(app.get_entry(a_id).unwrap().content, "");
+
+    app.redo().await.unwrap();
+    assert_eq!(app.get_entry(a_id).unwrap().content, "edited content");
+
+    app.redo().await.unwrap();
+    assert!(app.get_entry(a_id).is_none());
+}
+
+#[tokio::test]
 /// This test will run multiple delete calls, undo do them, then redo them
 async fn many() {
     let mut app = create_default_app();


### PR DESCRIPTION
This PR closes #623 

It's related to #626 but it tries to resolve the issue on the data provider level by:

* Add `restore_entry` to data providers for restoring deleted entries with their original ids.
* Use restore when applying delete undo instead of creating a new entry.
* Add regression tests for undo/redo after restoring a deleted entry and backend restore behavior.

@kotachisam I would appreciate it if you can review the changes and confirm that they are working before merging the PR