### PR TITLE
editor: snap to line start/end when vertical nav would be a no-op

### DIFF
--- a/src/app/ui/editor/mod.rs
+++ b/src/app/ui/editor/mod.rs
@@ -126,6 +126,10 @@ impl<'a> Editor<'a> {
                 }
             }
 
+            if self.try_snap_vertical_navigation(input) {
+                return Ok(HandleInputReturnType::Handled);
+            }
+
             // give the input to the editor
             let key_event = KeyEvent::from(input);
             if self.text_area.input(key_event) {
@@ -153,8 +157,10 @@ impl<'a> Editor<'a> {
         let sync_os_clipboard = app.settings.sync_os_clipboard;
 
         if is_default_navigation(input) {
-            let key_event = KeyEvent::from(input);
-            self.text_area.input(key_event);
+            if !self.try_snap_vertical_navigation(input) {
+                let key_event = KeyEvent::from(input);
+                self.text_area.input(key_event);
+            }
         } else if !self.is_visual_mode()
             || !self.handle_input_visual_only(input, sync_os_clipboard)?
         {
@@ -307,6 +313,33 @@ impl<'a> Editor<'a> {
         }
 
         Ok(())
+    }
+
+    /// Up on first line / Down on last line snaps to line start/end instead of no-op.
+    fn try_snap_vertical_navigation(&mut self, input: &Input) -> bool {
+        if !input.modifiers.is_empty() || self.is_visual_mode() {
+            return false;
+        }
+        match input.key_code {
+            KeyCode::Up if self.is_on_first_line() => {
+                self.text_area.move_cursor(CursorMove::Head);
+                true
+            }
+            KeyCode::Down if self.is_on_last_line() => {
+                self.text_area.move_cursor(CursorMove::End);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn is_on_first_line(&self) -> bool {
+        self.text_area.cursor().0 == 0
+    }
+
+    fn is_on_last_line(&self) -> bool {
+        let (row, _) = self.text_area.cursor();
+        row + 1 >= self.text_area.lines().len()
     }
 
     pub fn get_editor_mode(&self) -> EditorMode {

--- a/src/app/ui/editor/mod.rs
+++ b/src/app/ui/editor/mod.rs
@@ -25,18 +25,19 @@ pub enum EditorMode {
     Visual,
 }
 
-#[derive(Debug, Clone, Copy)]
-enum VerticalDir {
-    Up,
-    Down,
-}
-
 pub struct Editor<'a> {
     text_area: TextArea<'a>,
     mode: EditorMode,
     is_active: bool,
     is_dirty: bool,
     has_unsaved: bool,
+}
+
+/// Direction of a single-line vertical cursor movement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VerticalDir {
+    Up,
+    Down,
 }
 
 impl From<&Input> for KeyEvent {
@@ -132,7 +133,8 @@ impl<'a> Editor<'a> {
                 }
             }
 
-            if self.try_snap_vertical_navigation(input) {
+            if let Some(dir) = vertical_arrow_dir(input) {
+                self.move_cursor_vertical(dir, self.should_extend_selection(input));
                 return Ok(HandleInputReturnType::Handled);
             }
 
@@ -162,11 +164,11 @@ impl<'a> Editor<'a> {
 
         let sync_os_clipboard = app.settings.sync_os_clipboard;
 
-        if is_default_navigation(input) {
-            if !self.try_snap_vertical_navigation(input) {
-                let key_event = KeyEvent::from(input);
-                self.text_area.input(key_event);
-            }
+        if let Some(dir) = vertical_arrow_dir(input) {
+            self.move_cursor_vertical(dir, self.should_extend_selection(input));
+        } else if is_default_navigation(input) {
+            let key_event = KeyEvent::from(input);
+            self.text_area.input(key_event);
         } else if !self.is_visual_mode()
             || !self.handle_input_visual_only(input, sync_os_clipboard)?
         {
@@ -232,11 +234,11 @@ impl<'a> Editor<'a> {
             (KeyCode::Char('h'), false) => {
                 self.text_area.move_cursor(CursorMove::Back);
             }
-            (KeyCode::Char('j'), false) if !self.try_snap_vertical(VerticalDir::Down) => {
-                self.text_area.move_cursor(CursorMove::Down);
+            (KeyCode::Char('j'), false) => {
+                self.move_cursor_down(self.is_visual_mode());
             }
-            (KeyCode::Char('k'), false) if !self.try_snap_vertical(VerticalDir::Up) => {
-                self.text_area.move_cursor(CursorMove::Up);
+            (KeyCode::Char('k'), false) => {
+                self.move_cursor_up(self.is_visual_mode());
             }
             (KeyCode::Char('l'), false) => {
                 self.text_area.move_cursor(CursorMove::Forward);
@@ -321,33 +323,46 @@ impl<'a> Editor<'a> {
         Ok(())
     }
 
-    /// Snaps to line start/end when vertical navigation would otherwise be a no-op.
-    fn try_snap_vertical_navigation(&mut self, input: &Input) -> bool {
-        if !input.modifiers.is_empty() {
-            return false;
-        }
-        match input.key_code {
-            KeyCode::Up => self.try_snap_vertical(VerticalDir::Up),
-            KeyCode::Down => self.try_snap_vertical(VerticalDir::Down),
-            _ => false,
-        }
+    /// Moves the cursor up one line, snapping to the line start when already on the
+    /// first line so the key press is never a dead no-op. Extends the active
+    /// selection when `select` is set.
+    fn move_cursor_up(&mut self, select: bool) {
+        self.move_cursor_vertical(VerticalDir::Up, select);
     }
 
-    fn try_snap_vertical(&mut self, dir: VerticalDir) -> bool {
-        if self.is_visual_mode() {
-            return false;
-        }
-        match dir {
-            VerticalDir::Up if self.is_on_first_line() => {
-                self.text_area.move_cursor(CursorMove::Head);
-                true
+    /// Moves the cursor down one line, snapping to the line end when already on the
+    /// last line so the key press is never a dead no-op. Extends the active
+    /// selection when `select` is set.
+    fn move_cursor_down(&mut self, select: bool) {
+        self.move_cursor_vertical(VerticalDir::Down, select);
+    }
+
+    /// Single entry point for vertical cursor movement across all modes. Owns the
+    /// selection state, the snap-to-edge decision, and the move itself so callers
+    /// never fall back to the underlying text area's default navigation.
+    fn move_cursor_vertical(&mut self, dir: VerticalDir, select: bool) {
+        if select {
+            if !self.text_area.is_selecting() {
+                self.text_area.start_selection();
             }
-            VerticalDir::Down if self.is_on_last_line() => {
-                self.text_area.move_cursor(CursorMove::End);
-                true
-            }
-            _ => false,
+        } else {
+            self.text_area.cancel_selection();
         }
+
+        let cursor_move = match dir {
+            VerticalDir::Up if self.is_on_first_line() => CursorMove::Head,
+            VerticalDir::Up => CursorMove::Up,
+            VerticalDir::Down if self.is_on_last_line() => CursorMove::End,
+            VerticalDir::Down => CursorMove::Down,
+        };
+        self.text_area.move_cursor(cursor_move);
+    }
+
+    /// Whether a vertical move should extend a selection: always in visual mode,
+    /// and in insert mode when Shift is held.
+    fn should_extend_selection(&self, input: &Input) -> bool {
+        self.is_visual_mode()
+            || (self.is_insert_mode() && input.modifiers.contains(KeyModifiers::SHIFT))
     }
 
     fn is_on_first_line(&self) -> bool {
@@ -577,14 +592,26 @@ impl<'a> Editor<'a> {
     }
 }
 
+/// Maps a plain or Shift-modified Up/Down arrow to a vertical direction so that
+/// vertical movement is fully owned by [`Editor::move_cursor_vertical`]. Arrows
+/// carrying Ctrl/Alt keep their default-navigation handling.
+fn vertical_arrow_dir(input: &Input) -> Option<VerticalDir> {
+    if !(input.modifiers - KeyModifiers::SHIFT).is_empty() {
+        return None;
+    }
+    match input.key_code {
+        KeyCode::Up => Some(VerticalDir::Up),
+        KeyCode::Down => Some(VerticalDir::Down),
+        _ => None,
+    }
+}
+
 fn is_default_navigation(input: &Input) -> bool {
     let has_control = input.modifiers.contains(KeyModifiers::CONTROL);
     let has_alt = input.modifiers.contains(KeyModifiers::ALT);
     match input.key_code {
         KeyCode::Left
         | KeyCode::Right
-        | KeyCode::Up
-        | KeyCode::Down
         | KeyCode::Home
         | KeyCode::End
         | KeyCode::PageUp
@@ -602,4 +629,115 @@ fn is_default_navigation(input: &Input) -> bool {
 
 fn map_clipboard_error(err: arboard::Error) -> anyhow::Error {
     anyhow!("Error while communicating with the operation system clipboard.\nError Details: {err}",)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::keymap::Input;
+    use crossterm::event::{KeyCode, KeyModifiers};
+    use tui_textarea::{CursorMove, TextArea};
+
+    fn editor_with(lines: &[&str], row: u16, col: u16) -> Editor<'static> {
+        let mut editor = Editor::new();
+        editor.text_area = TextArea::new(lines.iter().map(|l| (*l).to_owned()).collect());
+        editor.text_area.move_cursor(CursorMove::Jump(row, col));
+        editor
+    }
+
+    #[test]
+    fn vertical_arrow_dir_maps_plain_and_shift_arrows() {
+        assert_eq!(
+            vertical_arrow_dir(&Input::new(KeyCode::Up, KeyModifiers::NONE)),
+            Some(VerticalDir::Up)
+        );
+        assert_eq!(
+            vertical_arrow_dir(&Input::new(KeyCode::Down, KeyModifiers::NONE)),
+            Some(VerticalDir::Down)
+        );
+        assert_eq!(
+            vertical_arrow_dir(&Input::new(KeyCode::Up, KeyModifiers::SHIFT)),
+            Some(VerticalDir::Up)
+        );
+    }
+
+    #[test]
+    fn vertical_arrow_dir_ignores_ctrl_alt_and_other_keys() {
+        assert_eq!(
+            vertical_arrow_dir(&Input::new(KeyCode::Up, KeyModifiers::CONTROL)),
+            None
+        );
+        assert_eq!(
+            vertical_arrow_dir(&Input::new(KeyCode::Down, KeyModifiers::ALT)),
+            None
+        );
+        assert_eq!(
+            vertical_arrow_dir(&Input::new(KeyCode::Left, KeyModifiers::NONE)),
+            None
+        );
+        assert_eq!(
+            vertical_arrow_dir(&Input::new(KeyCode::Char('k'), KeyModifiers::NONE)),
+            None
+        );
+    }
+
+    #[test]
+    fn up_on_first_line_snaps_to_head() {
+        let mut editor = editor_with(&["hello", "world"], 0, 3);
+        editor.move_cursor_up(false);
+        assert_eq!(editor.text_area.cursor(), (0, 0));
+        assert!(!editor.text_area.is_selecting());
+    }
+
+    #[test]
+    fn up_mid_buffer_moves_one_line_without_snapping() {
+        let mut editor = editor_with(&["a", "bb", "ccc"], 2, 1);
+        editor.move_cursor_up(false);
+        assert_eq!(editor.text_area.cursor().0, 1);
+    }
+
+    #[test]
+    fn down_on_last_line_snaps_to_end() {
+        let mut editor = editor_with(&["hello", "world"], 1, 0);
+        editor.move_cursor_down(false);
+        assert_eq!(editor.text_area.cursor(), (1, 5));
+    }
+
+    #[test]
+    fn down_mid_buffer_moves_one_line_without_snapping() {
+        let mut editor = editor_with(&["a", "bb", "ccc"], 0, 0);
+        editor.move_cursor_down(false);
+        assert_eq!(editor.text_area.cursor().0, 1);
+    }
+
+    #[test]
+    fn snap_with_select_extends_selection() {
+        let mut editor = editor_with(&["hello", "world"], 0, 3);
+        editor.move_cursor_up(true);
+        assert_eq!(editor.text_area.cursor(), (0, 0));
+        assert!(editor.text_area.is_selecting());
+    }
+
+    #[test]
+    fn move_without_select_cancels_existing_selection() {
+        let mut editor = editor_with(&["a", "bb", "ccc"], 2, 1);
+        editor.text_area.start_selection();
+        editor.move_cursor_up(false);
+        assert!(!editor.text_area.is_selecting());
+    }
+
+    #[test]
+    fn should_extend_selection_depends_on_mode_and_shift() {
+        let mut editor = editor_with(&["abc"], 0, 0);
+
+        editor.mode = EditorMode::Normal;
+        assert!(!editor.should_extend_selection(&Input::new(KeyCode::Up, KeyModifiers::SHIFT)));
+
+        editor.mode = EditorMode::Insert;
+        assert!(editor.should_extend_selection(&Input::new(KeyCode::Up, KeyModifiers::SHIFT)));
+        assert!(!editor.should_extend_selection(&Input::new(KeyCode::Up, KeyModifiers::NONE)));
+
+        editor.mode = EditorMode::Visual;
+        assert!(editor.should_extend_selection(&Input::new(KeyCode::Up, KeyModifiers::NONE)));
+    }
 }

--- a/src/app/ui/editor/mod.rs
+++ b/src/app/ui/editor/mod.rs
@@ -610,7 +610,8 @@ impl<'a> Editor<'a> {
 /// vertical movement is fully owned by [`Editor::move_cursor_vertical`]. Arrows
 /// carrying Ctrl/Alt keep their default-navigation handling.
 fn vertical_arrow_dir(input: &Input) -> Option<VerticalDir> {
-    if !(input.modifiers - KeyModifiers::SHIFT).is_empty() {
+    let modifiers = input.modifiers;
+    if !modifiers.is_empty() && modifiers != KeyModifiers::SHIFT {
         return None;
     }
     match input.key_code {
@@ -626,6 +627,8 @@ fn is_default_navigation(input: &Input) -> bool {
     match input.key_code {
         KeyCode::Left
         | KeyCode::Right
+        | KeyCode::Up
+        | KeyCode::Down
         | KeyCode::Home
         | KeyCode::End
         | KeyCode::PageUp
@@ -693,6 +696,26 @@ mod tests {
             vertical_arrow_dir(&Input::new(KeyCode::Char('k'), KeyModifiers::NONE)),
             None
         );
+    }
+
+    #[test]
+    fn modified_vertical_arrows_stay_default_navigation() {
+        assert!(is_default_navigation(&Input::new(
+            KeyCode::Up,
+            KeyModifiers::CONTROL
+        )));
+        assert!(is_default_navigation(&Input::new(
+            KeyCode::Down,
+            KeyModifiers::CONTROL
+        )));
+        assert!(is_default_navigation(&Input::new(
+            KeyCode::Up,
+            KeyModifiers::ALT
+        )));
+        assert!(is_default_navigation(&Input::new(
+            KeyCode::Down,
+            KeyModifiers::ALT
+        )));
     }
 
     #[test]

--- a/src/app/ui/editor/mod.rs
+++ b/src/app/ui/editor/mod.rs
@@ -25,6 +25,12 @@ pub enum EditorMode {
     Visual,
 }
 
+#[derive(Debug, Clone, Copy)]
+enum VerticalDir {
+    Up,
+    Down,
+}
+
 pub struct Editor<'a> {
     text_area: TextArea<'a>,
     mode: EditorMode,
@@ -226,10 +232,10 @@ impl<'a> Editor<'a> {
             (KeyCode::Char('h'), false) => {
                 self.text_area.move_cursor(CursorMove::Back);
             }
-            (KeyCode::Char('j'), false) => {
+            (KeyCode::Char('j'), false) if !self.try_snap_vertical(VerticalDir::Down) => {
                 self.text_area.move_cursor(CursorMove::Down);
             }
-            (KeyCode::Char('k'), false) => {
+            (KeyCode::Char('k'), false) if !self.try_snap_vertical(VerticalDir::Up) => {
                 self.text_area.move_cursor(CursorMove::Up);
             }
             (KeyCode::Char('l'), false) => {
@@ -315,17 +321,28 @@ impl<'a> Editor<'a> {
         Ok(())
     }
 
-    /// Up on first line / Down on last line snaps to line start/end instead of no-op.
+    /// Snaps to line start/end when vertical navigation would otherwise be a no-op.
     fn try_snap_vertical_navigation(&mut self, input: &Input) -> bool {
-        if !input.modifiers.is_empty() || self.is_visual_mode() {
+        if !input.modifiers.is_empty() {
             return false;
         }
         match input.key_code {
-            KeyCode::Up if self.is_on_first_line() => {
+            KeyCode::Up => self.try_snap_vertical(VerticalDir::Up),
+            KeyCode::Down => self.try_snap_vertical(VerticalDir::Down),
+            _ => false,
+        }
+    }
+
+    fn try_snap_vertical(&mut self, dir: VerticalDir) -> bool {
+        if self.is_visual_mode() {
+            return false;
+        }
+        match dir {
+            VerticalDir::Up if self.is_on_first_line() => {
                 self.text_area.move_cursor(CursorMove::Head);
                 true
             }
-            KeyCode::Down if self.is_on_last_line() => {
+            VerticalDir::Down if self.is_on_last_line() => {
                 self.text_area.move_cursor(CursorMove::End);
                 true
             }

--- a/src/app/ui/editor/mod.rs
+++ b/src/app/ui/editor/mod.rs
@@ -341,6 +341,10 @@ impl<'a> Editor<'a> {
     /// selection state, the snap-to-edge decision, and the move itself so callers
     /// never fall back to the underlying text area's default navigation.
     fn move_cursor_vertical(&mut self, dir: VerticalDir, select: bool) {
+        let Some(cursor_move) = self.resolve_vertical_move(dir) else {
+            return;
+        };
+
         if select {
             if !self.text_area.is_selecting() {
                 self.text_area.start_selection();
@@ -349,20 +353,30 @@ impl<'a> Editor<'a> {
             self.text_area.cancel_selection();
         }
 
-        let cursor_move = match dir {
-            VerticalDir::Up if self.is_on_first_line() => CursorMove::Head,
-            VerticalDir::Up => CursorMove::Up,
-            VerticalDir::Down if self.is_on_last_line() => CursorMove::End,
-            VerticalDir::Down => CursorMove::Down,
-        };
         self.text_area.move_cursor(cursor_move);
     }
 
+    /// Resolves a direction to the concrete move to apply, snapping to the line
+    /// edge on the first and last lines. Yields `None` when the cursor already
+    /// sits on the edge it would snap to, so a dead key press leaves both the
+    /// cursor and the selection untouched.
+    fn resolve_vertical_move(&self, dir: VerticalDir) -> Option<CursorMove> {
+        let (row, col) = self.text_area.cursor();
+        match dir {
+            VerticalDir::Up if self.is_on_first_line() => (col > 0).then_some(CursorMove::Head),
+            VerticalDir::Up => Some(CursorMove::Up),
+            VerticalDir::Down if self.is_on_last_line() => {
+                let line_end = self.text_area.lines()[row].chars().count();
+                (col < line_end).then_some(CursorMove::End)
+            }
+            VerticalDir::Down => Some(CursorMove::Down),
+        }
+    }
+
     /// Whether a vertical move should extend a selection: always in visual mode,
-    /// and in insert mode when Shift is held.
+    /// and in any other mode while Shift is held, as a conventional editor does.
     fn should_extend_selection(&self, input: &Input) -> bool {
-        self.is_visual_mode()
-            || (self.is_insert_mode() && input.modifiers.contains(KeyModifiers::SHIFT))
+        self.is_visual_mode() || input.modifiers.contains(KeyModifiers::SHIFT)
     }
 
     fn is_on_first_line(&self) -> bool {
@@ -727,11 +741,49 @@ mod tests {
     }
 
     #[test]
+    fn shift_selects_in_normal_mode_without_leaving_it() {
+        let mut editor = editor_with(&["hello", "world"], 0, 3);
+        editor.mode = EditorMode::Normal;
+
+        editor.move_cursor_vertical(
+            VerticalDir::Up,
+            editor.should_extend_selection(&Input::new(KeyCode::Up, KeyModifiers::SHIFT)),
+        );
+
+        assert_eq!(editor.text_area.cursor(), (0, 0));
+        assert_eq!(editor.text_area.selection_range(), Some(((0, 0), (0, 3))));
+        assert_eq!(editor.mode, EditorMode::Normal);
+    }
+
+    #[test]
+    fn dead_key_press_leaves_selection_untouched() {
+        let mut editor = editor_with(&["hello", "world"], 0, 0);
+        editor.move_cursor_up(true);
+        assert!(!editor.text_area.is_selecting());
+
+        let mut editor = editor_with(&["hello", "world"], 1, 5);
+        editor.move_cursor_down(true);
+        assert!(!editor.text_area.is_selecting());
+    }
+
+    #[test]
+    fn dead_key_press_preserves_an_existing_selection() {
+        let mut editor = editor_with(&["hello", "world"], 0, 3);
+        editor.move_cursor_up(true);
+        let selection = editor.text_area.selection_range();
+
+        editor.move_cursor_up(true);
+
+        assert_eq!(editor.text_area.selection_range(), selection);
+    }
+
+    #[test]
     fn should_extend_selection_depends_on_mode_and_shift() {
         let mut editor = editor_with(&["abc"], 0, 0);
 
         editor.mode = EditorMode::Normal;
-        assert!(!editor.should_extend_selection(&Input::new(KeyCode::Up, KeyModifiers::SHIFT)));
+        assert!(editor.should_extend_selection(&Input::new(KeyCode::Up, KeyModifiers::SHIFT)));
+        assert!(!editor.should_extend_selection(&Input::new(KeyCode::Up, KeyModifiers::NONE)));
 
         editor.mode = EditorMode::Insert;
         assert!(editor.should_extend_selection(&Input::new(KeyCode::Up, KeyModifiers::SHIFT)));


### PR DESCRIPTION
Up on the first line and Down on the last line previously did nothing. Snap to Head/End respectively so the keypress always has a useful effect, mirroring the double-Esc convention of turning a dead key into something helpful. Modifier keys (shift/ctrl/alt) bypass the snap so selection extension and other bindings continue to work as before.

Applies to default-navigation paths in insert and normal only; vim-style jk bindings in normal mode have now been adjusted to match with the Up/Down arrow keys (commit [73dd456](https://github.com/AmmarAbouZor/tui-journal/pull/628/commits/73dd456081a0304745d917d63ee4fd5a315fdf9e). Visual mode is left alone: plain arrows there already cancel selection, and we don't want to introduce a competing snap behavior. 

## Manual testing
 - Insert mode, single-line entry: Up/Down snap to start/end
 - Multi-line, cursor on first line: Up snaps to Head; mid-buffer still moves up
 - Multi-line, cursor on last line: Down snaps to End
 - Shift+Up on first line: still extends selection (no snap) 
 - Visual mode: unaffected — arrow keys keep their existing cancel-selection behavior
 - Normal mode k on first line: snaps to Head.
 - Normal mode j on last line, snaps to End.

## Contribution and AI Policy
- [x] I have read and accept the Contribution and AI Policy in `README.md`, and I have reviewed this PR myself.
