### PR TITLE
feat(settings,ui): add configurable date format

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,24 @@ colored_tags = true   # Sets if automatically coloring for tags is enabled.
 #  - `empty_line`: Hide datum providing an extra empty line for journal without `priority` value.
 datum_visibility = "show"
 
+# Sets the format used to render the datum of journals, and to read the date while
+# creating or editing a journal.
+# The value is written with date tokens, which are translated to their `strftime` equivalents:
+#  - `YYYY`: Year with century (2026).
+#  - `YY`:   Year without century (26).
+#  - `MM`:   Month, zero-padded (04).
+#  - `M`:    Month, without padding (4).
+#  - `DD`:   Day, zero-padded (07).
+#  - `D`:    Day, without padding (7).
+# Every other character is kept as it is, so any separator can be used: "YYYY/MM/DD".
+# Note that a `D`, `M` or `Y` is translated everywhere it appears, including inside a word.
+# If the value contains a `%` it's handed to `strftime` as it is without any translation,
+# which gives access to the full set of its specifiers: "%A %d %B %Y".
+# A value that can't render a date and read it back again -- an unknown specifier like "%Q",
+# or one too lossy to round-trip like "YYYY" -- falls back to the default.
+# Default value: "DD-MM-YYYY"
+date_format = "YYYY-MM-DD"
+
 # Sets the directory where the application persists its state between sessions.
 # Default are "~/<HOME>/.local/state/tui-journal/" on Linux and "C:\Users\Alice\AppData\Roaming\tui-journal\" on Windows
 app_state_dir = "<STATE_DIRECTORY>/tui-journal/"

--- a/src/app/ui/commands/entries_list_cmd.rs
+++ b/src/app/ui/commands/entries_list_cmd.rs
@@ -165,7 +165,10 @@ fn edit_current_entry<D: DataProvider>(ui_components: &mut UIComponents, app: &m
     if let Some(entry) = app.get_current_entry() {
         ui_components
             .popup_stack
-            .push(Popup::Entry(Box::new(EntryPopup::from_entry(entry))));
+            .push(Popup::Entry(Box::new(EntryPopup::from_entry(
+                entry,
+                &app.settings,
+            ))));
     }
 }
 

--- a/src/app/ui/entries_list/mod.rs
+++ b/src/app/ui/entries_list/mod.rs
@@ -1,5 +1,3 @@
-use chrono::Datelike;
-
 use ratatui::{
     Frame,
     layout::{Alignment, Rect},
@@ -82,35 +80,17 @@ impl EntriesList {
                 // *** Date & Priority ***
                 let date_priority_lines = match (app.settings.datum_visibility, entry.priority) {
                     (DatumVisibility::Show, Some(prio)) => {
-                        let one_liner = format!(
-                            "{},{},{} | Priority: {}",
-                            entry.date.day(),
-                            entry.date.month(),
-                            entry.date.year(),
-                            prio
-                        );
+                        let date_text = app.settings.date_format.display(&entry.date);
+                        let one_liner = format!("{date_text} | Priority: {prio}");
 
                         if one_liner.len() > area.width as usize - LIST_INNER_MARGIN {
-                            vec![
-                                format!(
-                                    "{},{},{}",
-                                    entry.date.day(),
-                                    entry.date.month(),
-                                    entry.date.year()
-                                ),
-                                format!("Priority: {prio}"),
-                            ]
+                            vec![date_text, format!("Priority: {prio}")]
                         } else {
                             vec![one_liner]
                         }
                     }
                     (DatumVisibility::Show, None) => {
-                        vec![format!(
-                            "{},{},{}",
-                            entry.date.day(),
-                            entry.date.month(),
-                            entry.date.year()
-                        )]
+                        vec![app.settings.date_format.display(&entry.date)]
                     }
                     (DatumVisibility::Hide, None) => Vec::new(),
                     (DatumVisibility::EmptyLine, None) => vec![String::new()],

--- a/src/app/ui/entry_popup/mod.rs
+++ b/src/app/ui/entry_popup/mod.rs
@@ -1,5 +1,5 @@
 use anyhow::Ok;
-use chrono::{Datelike, Local, NaiveDate, TimeZone, Utc};
+use chrono::{Datelike, Local, TimeZone, Utc};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
     Frame,
@@ -11,7 +11,7 @@ use tui_textarea::{CursorMove, TextArea};
 
 use crate::{
     app::{App, keymap::Input},
-    settings::Settings,
+    settings::{DateFormat, Settings},
 };
 
 use backend::{DataProvider, Entry};
@@ -37,6 +37,7 @@ pub struct EntryPopup<'a> {
     tags_err_msg: String,
     priority_err_msg: String,
     tags_popup: Option<TagsPopup>,
+    date_format: DateFormat,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -66,12 +67,7 @@ impl EntryPopup<'_> {
 
         let date = Local::now();
 
-        let date_txt = TextArea::new(vec![format!(
-            "{:02}-{:02}-{}",
-            date.day(),
-            date.month(),
-            date.year()
-        )]);
+        let date_txt = TextArea::new(vec![settings.date_format.display(&date)]);
 
         let tags_txt = TextArea::default();
 
@@ -93,19 +89,15 @@ impl EntryPopup<'_> {
             tags_err_msg: String::default(),
             priority_err_msg: String::default(),
             tags_popup: None,
+            date_format: settings.date_format.clone(),
         }
     }
 
-    pub fn from_entry(entry: &Entry) -> Self {
+    pub fn from_entry(entry: &Entry, settings: &Settings) -> Self {
         let mut title_txt = TextArea::new(vec![entry.title.to_owned()]);
         title_txt.move_cursor(CursorMove::End);
 
-        let date_txt = TextArea::new(vec![format!(
-            "{:02}-{:02}-{}",
-            entry.date.day(),
-            entry.date.month(),
-            entry.date.year()
-        )]);
+        let date_txt = TextArea::new(vec![settings.date_format.display(&entry.date)]);
 
         let tags = tags_to_text(&entry.tags);
 
@@ -129,6 +121,7 @@ impl EntryPopup<'_> {
             tags_err_msg: String::default(),
             priority_err_msg: String::default(),
             tags_popup: None,
+            date_format: settings.date_format.clone(),
         };
 
         entry_popup.validate_all();
@@ -352,7 +345,7 @@ impl EntryPopup<'_> {
     }
 
     fn validate_date(&mut self) {
-        if let Err(err) = NaiveDate::parse_from_str(self.date_txt.lines()[0].as_str(), "%d-%m-%Y") {
+        if let Err(err) = self.date_format.parse(self.date_txt.lines()[0].as_str()) {
             self.date_err_msg = err.to_string();
         } else {
             self.date_err_msg.clear();
@@ -488,7 +481,9 @@ impl EntryPopup<'_> {
         }
 
         let title = self.title_txt.lines()[0].to_owned();
-        let date = NaiveDate::parse_from_str(self.date_txt.lines()[0].as_str(), "%d-%m-%Y")
+        let date = self
+            .date_format
+            .parse(self.date_txt.lines()[0].as_str())
             .expect("Date must be valid here");
 
         let date = Utc

--- a/src/settings/date_format.rs
+++ b/src/settings/date_format.rs
@@ -1,0 +1,322 @@
+use std::fmt::Write as _;
+
+use chrono::{DateTime, NaiveDate, ParseResult, TimeZone, Utc};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+const DEFAULT_PATTERN: &str = "DD-MM-YYYY";
+
+/// Dates a candidate pattern must survive rendering and re-parsing. Two dates
+/// so a pattern can't pass by coincidence on single-digit or padded values.
+const PROBE_DATES: [(i32, u32, u32); 2] = [(2026, 4, 3), (2026, 12, 31)];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DateFormat {
+    /// The pattern as the user wrote it, kept so `print-config` reports back
+    /// what was configured rather than its strftime translation.
+    pattern: String,
+    strftime: String,
+}
+
+impl DateFormat {
+    /// Builds a format from a user-supplied pattern, falling back to the
+    /// default when the pattern can't render a date and read it back. chrono
+    /// panics rather than erroring on an unknown specifier at format time, and
+    /// every caller is on the render path, so an unusable pattern has to be
+    /// rejected here.
+    pub fn new(pattern: &str) -> Self {
+        let strftime = to_strftime(pattern);
+
+        if round_trips(&strftime) {
+            Self {
+                pattern: pattern.to_owned(),
+                strftime,
+            }
+        } else {
+            Self::default()
+        }
+    }
+
+    pub fn display<Tz: TimeZone>(&self, date: &DateTime<Tz>) -> String
+    where
+        Tz::Offset: std::fmt::Display,
+    {
+        date.format(&self.strftime).to_string()
+    }
+
+    pub fn parse(&self, s: &str) -> ParseResult<NaiveDate> {
+        NaiveDate::parse_from_str(s, &self.strftime)
+    }
+}
+
+impl Default for DateFormat {
+    fn default() -> Self {
+        Self {
+            pattern: DEFAULT_PATTERN.to_owned(),
+            strftime: to_strftime(DEFAULT_PATTERN),
+        }
+    }
+}
+
+impl Serialize for DateFormat {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.pattern)
+    }
+}
+
+impl<'de> Deserialize<'de> for DateFormat {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(Self::new(&s))
+    }
+}
+
+fn to_strftime(pattern: &str) -> String {
+    if pattern.contains('%') {
+        pattern.to_owned()
+    } else {
+        translate_dsl(pattern)
+    }
+}
+
+/// A pattern is usable only if it can render a date and parse that rendering
+/// back to the same date. This rejects unknown specifiers, which would
+/// otherwise panic on the next redraw, along with patterns too lossy to
+/// round-trip (`"%Y"` renders but carries no month or day).
+fn round_trips(strftime: &str) -> bool {
+    PROBE_DATES.iter().all(|&(year, month, day)| {
+        let Some(expected) = NaiveDate::from_ymd_opt(year, month, day) else {
+            return false;
+        };
+        let Some(probe) = Utc.with_ymd_and_hms(year, month, day, 0, 0, 0).single() else {
+            return false;
+        };
+
+        let mut rendered = String::new();
+        if write!(rendered, "{}", probe.format(strftime)).is_err() {
+            return false;
+        }
+
+        NaiveDate::parse_from_str(&rendered, strftime) == Ok(expected)
+    })
+}
+
+fn translate_dsl(pattern: &str) -> String {
+    let mut out = String::new();
+    let mut remaining = pattern;
+    while !remaining.is_empty() {
+        if let Some(rest) = remaining.strip_prefix("YYYY") {
+            out.push_str("%Y");
+            remaining = rest;
+        } else if let Some(rest) = remaining.strip_prefix("YY") {
+            out.push_str("%y");
+            remaining = rest;
+        } else if let Some(rest) = remaining.strip_prefix("MM") {
+            out.push_str("%m");
+            remaining = rest;
+        } else if let Some(rest) = remaining.strip_prefix("M") {
+            out.push_str("%-m");
+            remaining = rest;
+        } else if let Some(rest) = remaining.strip_prefix("DD") {
+            out.push_str("%d");
+            remaining = rest;
+        } else if let Some(rest) = remaining.strip_prefix("D") {
+            out.push_str("%-d");
+            remaining = rest;
+        } else {
+            let mut chars = remaining.chars();
+            if let Some(c) = chars.next() {
+                out.push(c);
+            }
+            remaining = chars.as_str();
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    #[test]
+    fn dsl_translates_basic_tokens() {
+        assert_eq!(translate_dsl("DD-MM-YYYY"), "%d-%m-%Y");
+        assert_eq!(translate_dsl("D/M/YY"), "%-d/%-m/%y");
+        assert_eq!(translate_dsl("YYYY.MM.DD"), "%Y.%m.%d");
+    }
+
+    #[test]
+    fn dsl_passes_through_literals() {
+        assert_eq!(translate_dsl("foo DD bar"), "foo %d bar");
+        assert_eq!(translate_dsl(""), "");
+    }
+
+    #[test]
+    fn new_accepts_raw_strftime() {
+        let df = DateFormat::new("%d/%m/%Y");
+        let date = Utc.with_ymd_and_hms(2026, 4, 23, 0, 0, 0).unwrap();
+        assert_eq!(df.display(&date), "23/04/2026");
+    }
+
+    #[test]
+    fn percent_leaves_the_whole_pattern_untranslated() {
+        let date = Utc.with_ymd_and_hms(2026, 4, 7, 0, 0, 0).unwrap();
+
+        assert_eq!(DateFormat::new("%D").display(&date), "04/07/26");
+        assert_eq!(
+            DateFormat::new("%A %d %B %Y").display(&date),
+            "Tuesday 07 April 2026"
+        );
+    }
+
+    /// Documented limitation: translation is positional, so a literal word
+    /// containing D, M or Y is rewritten too. The `%` escape hatch is the way
+    /// out, and the README says so beside the setting.
+    #[test]
+    fn tokens_are_translated_inside_literal_words() {
+        assert_eq!(translate_dsl("Day DD"), "%-day %d");
+    }
+
+    #[test]
+    fn new_translates_dsl_to_strftime() {
+        let df = DateFormat::new("DD/MM/YYYY");
+        let date = Utc.with_ymd_and_hms(2026, 4, 23, 0, 0, 0).unwrap();
+        assert_eq!(df.display(&date), "23/04/2026");
+    }
+
+    #[test]
+    fn default_is_padded_dmy_dashes() {
+        let df = DateFormat::default();
+        let date = Utc.with_ymd_and_hms(2026, 4, 23, 0, 0, 0).unwrap();
+        assert_eq!(df.display(&date), "23-04-2026");
+    }
+
+    #[test]
+    fn display_formats_padded() {
+        let df = DateFormat::new("DD-MM-YYYY");
+        let date = Utc.with_ymd_and_hms(2026, 4, 23, 0, 0, 0).unwrap();
+        assert_eq!(df.display(&date), "23-04-2026");
+    }
+
+    #[test]
+    fn display_respects_unpadded_tokens() {
+        let df = DateFormat::new("D/M/YY");
+        let date = Utc.with_ymd_and_hms(2026, 4, 3, 0, 0, 0).unwrap();
+        assert_eq!(df.display(&date), "3/4/26");
+    }
+
+    #[test]
+    fn parse_round_trips() {
+        let df = DateFormat::new("DD-MM-YYYY");
+        let date = df.parse("23-04-2026").unwrap();
+        assert_eq!(date, NaiveDate::from_ymd_opt(2026, 4, 23).unwrap());
+    }
+
+    #[test]
+    fn parse_follows_the_configured_format() {
+        let df = DateFormat::new("YYYY-MM-DD");
+
+        assert_eq!(
+            df.parse("2026-04-23").unwrap(),
+            NaiveDate::from_ymd_opt(2026, 4, 23).unwrap()
+        );
+        assert!(df.parse("23-04-2026").is_err());
+    }
+
+    #[test]
+    fn an_unknown_specifier_falls_back_to_the_default() {
+        let df = DateFormat::new("%Q");
+        let date = Utc.with_ymd_and_hms(2026, 4, 23, 0, 0, 0).unwrap();
+
+        assert_eq!(df, DateFormat::default());
+        assert_eq!(df.display(&date), "23-04-2026");
+    }
+
+    #[test]
+    fn a_pattern_that_cannot_round_trip_falls_back_to_the_default() {
+        assert_eq!(DateFormat::new("YYYY"), DateFormat::default());
+        assert_eq!(DateFormat::new("%Y"), DateFormat::default());
+    }
+
+    #[test]
+    fn every_documented_pattern_is_accepted() {
+        for pattern in [
+            "DD-MM-YYYY",
+            "YYYY-MM-DD",
+            "D/M/YY",
+            "YYYY.MM.DD",
+            "%A %d %B %Y",
+        ] {
+            assert_eq!(
+                DateFormat::new(pattern).pattern,
+                pattern,
+                "{pattern} should be kept, not replaced by the fallback"
+            );
+        }
+    }
+
+    #[test]
+    fn a_rendered_date_parses_back_for_every_documented_pattern() {
+        let date = Utc.with_ymd_and_hms(2026, 4, 3, 0, 0, 0).unwrap();
+        let expected = NaiveDate::from_ymd_opt(2026, 4, 3).unwrap();
+
+        for pattern in [
+            "DD-MM-YYYY",
+            "YYYY-MM-DD",
+            "D/M/YY",
+            "YYYY.MM.DD",
+            "%A %d %B %Y",
+        ] {
+            let df = DateFormat::new(pattern);
+            assert_eq!(df.parse(&df.display(&date)), Ok(expected), "{pattern}");
+        }
+    }
+
+    #[test]
+    fn serializing_gives_back_the_pattern_the_user_wrote() {
+        #[derive(Serialize)]
+        struct Wrapper {
+            date_format: DateFormat,
+        }
+
+        let toml = toml::to_string(&Wrapper {
+            date_format: DateFormat::new("DD-MM-YYYY"),
+        })
+        .unwrap();
+
+        assert_eq!(toml.trim(), r#"date_format = "DD-MM-YYYY""#);
+    }
+
+    #[test]
+    fn serializing_a_rejected_pattern_reports_the_effective_default() {
+        #[derive(Serialize)]
+        struct Wrapper {
+            date_format: DateFormat,
+        }
+
+        let toml = toml::to_string(&Wrapper {
+            date_format: DateFormat::new("%Q"),
+        })
+        .unwrap();
+
+        assert_eq!(toml.trim(), r#"date_format = "DD-MM-YYYY""#);
+    }
+
+    #[test]
+    fn deserializing_a_rejected_pattern_falls_back_instead_of_failing() {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            date_format: DateFormat,
+        }
+
+        let parsed: Wrapper = toml::from_str(r#"date_format = "%Q""#).unwrap();
+
+        assert_eq!(parsed.date_format, DateFormat::default());
+    }
+}

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -24,6 +24,8 @@ use self::sqlite_backend::{SqliteBackend, get_default_sqlite_path};
 use self::vjournal_backend::{VjournalBackend, get_default_vjournal_path};
 use self::{auto_title::AutoTitle, export::ExportSettings, external_editor::ExternalEditor};
 
+pub use self::date_format::DateFormat;
+
 #[cfg(feature = "json")]
 pub mod json_backend;
 #[cfg(feature = "sqlite")]
@@ -32,6 +34,7 @@ pub mod sqlite_backend;
 pub mod vjournal_backend;
 
 mod auto_title;
+mod date_format;
 mod export;
 mod external_editor;
 
@@ -70,6 +73,10 @@ pub struct Settings {
     #[serde(default)]
     /// Sets the visibility options for the datum of journals when rendered in entries list.
     pub datum_visibility: DatumVisibility,
+    #[serde(default)]
+    /// Format used to display and parse dates across the entries list and popups.
+    /// Accepts DSL tokens (DD, D, MM, M, YYYY, YY) or raw strftime (`%d-%m-%Y`).
+    pub date_format: DateFormat,
     /// Overwrite the path for the directory used to persist the app state.
     pub app_state_dir: Option<PathBuf>,
 }
@@ -93,6 +100,7 @@ impl Default for Settings {
             history_limit: default_history_limit(),
             colored_tags: default_colored_tags(),
             datum_visibility: Default::default(),
+            date_format: Default::default(),
             app_state_dir: Default::default(),
         }
     }
@@ -197,6 +205,7 @@ impl Settings {
             history_limit: _,
             colored_tags: _,
             datum_visibility: _,
+            date_format: _,
             app_state_dir: _,
         } = self;
 


### PR DESCRIPTION
Closes #591

## Summary

Adds a `date_format` config key. Accepts a token DSL (`DD-MM-YYYY`, `D/M/YY`) or, when the value contains a `%`, raw strftime passed through unchanged (`%A %d %B %Y`). Display and input parsing share the format, so the entries list
and both popups round-trip.

Default is `DD-MM-YYYY`, which also unifies the list view (previously unpadded `{},{},{}`) with the popup (`{:02}-{:02}-{}`).

A pattern is only accepted if it can render a date and parse that rendering back; otherwise the default is used. chrono panics rather than erroring on an unknown specifier and every call site is on the render path, so a typo like `%Q` would crash on redraw. This also rejects patterns too lossy to re-enter, like `%Y`.

## Contribution and AI Policy

- [x] I have read and accept the Contribution and AI Policy in `README.md`, and I have reviewed this PR myself.
